### PR TITLE
Bug fix: Print progress in run_top_fraction

### DIFF
--- a/epydemix/calibration/abc.py
+++ b/epydemix/calibration/abc.py
@@ -285,7 +285,7 @@ class ABCSampler:
         if verbose:
             print(f"Starting ABC top fraction selection with {Nsim} simulations and top {top_fraction*100:.1f}% selected")
         
-        for _ in range(Nsim):
+        for n in range(Nsim):
             params = self._sample_parameters()
             simulation = self._run_simulation(params)
             distance = self.distance_function(self.observed_data, simulation)
@@ -295,10 +295,10 @@ class ABCSampler:
             for i, p in enumerate(self.param_names):
                 sampled_params[p].append(params[i])
 
-        # Print progress every 10% if verbose
-        if verbose and (i + 1) % max(1, Nsim // 10) == 0:
-            print(f"\tProgress: {i + 1}/{Nsim} simulations completed ({(i + 1)/Nsim*100:.1f}%)")
-            
+            # Print progress every 10% if verbose
+            if verbose and (n + 1) % max(1, Nsim // 10) == 0:
+                print(f"\tProgress: {n + 1}/{Nsim} simulations completed ({(n + 1)/Nsim*100:.1f}%)")
+
         # Select top fraction
         threshold = np.quantile(distances, top_fraction)
         mask = np.array(distances) <= threshold


### PR DESCRIPTION
### Overview
This pull request fixes the following bug:

The progress does not get printed in top_fraction ABC even when `verbose=True` is set.
```txt
Starting ABC top fraction selection with 5000 simulations and top 5.0% selected
        Selected 250 particles (top 5.0%) with distance threshold 1068.171419
```

### Cause
This bug is due to following lines, which is outside of the for loop `for _ in range(Nsim):`.
https://github.com/epistorm/epydemix/blob/24d51179aae796c1932af945e1854f56425b17f3/epydemix/calibration/abc.py#L298-L300

### Changes made
- Change index of for-loop to `n` from `_`
- Bring if-statement inside the for loop, and use `n` to calculate progress