### PR TITLE
Migrate lint/format to Ruff, add CONTRIBUTING.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,25 @@ on:
       - '**'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+      - name: Run ruff format
+        run: ruff format --check .
+      - name: Run ruff
+        run: ruff check .
   test:
+    needs: lint
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.14.6
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+    # Run the formatter.
+    - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Epydemix
+
+First off, thank you for considering contributing to Epydemix!
+
+## Getting Started
+
+1.  Fork the repository on GitHub.
+2.  Clone your forked repository locally.
+3.  Install the dependencies (including development dependencies):
+
+    ```bash
+    pip install -r requirements.txt
+    pip install -r dev-requirements.txt
+    ```
+
+4.  Install the pre-commit hook:
+
+    ```bash
+    pre-commit install
+    ```
+
+## Development Workflow
+
+1.  Create a new branch for your feature or bug fix.
+2.  Make your changes.
+3.  Run `ruff` to format and lint your code:
+
+    ```bash
+    ruff format .
+    ruff check .
+    ```
+
+4.  Commit your changes. The pre-commit hook will automatically run `ruff` and fix any issues it can.
+5.  Push your changes to your forked repository.
+6.  Open a pull request on the main Epydemix repository.
+
+## Code Style
+
+We use `ruff` to format and lint our code.
+
+Please make sure your code conforms to the `ruff` configuration in `pyproject.toml`.
+
+## Testing
+
+We use `pytest` for testing. Please make sure all tests pass before submitting a pull request.
+
+To run the tests, use the following command:
+
+```bash
+pytest
+```
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+ruff==0.14.6
+pytest
+pytest-cov
+pre-commit

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,26 +1,24 @@
 import os
 import sys
-import sphinx_rtd_theme
 
-sys.path.insert(0, os.path.abspath('../..'))  
+sys.path.insert(0, os.path.abspath("../.."))
 
 
-project = 'epydemix'
-copyright = '2025, The epydemix developers'
-author = 'The epydemix developers'
-release = '1.0.2'
+project = "epydemix"
+copyright = "2025, The epydemix developers"
+author = "The epydemix developers"
+release = "1.0.2"
 
 extensions = [
-    "sphinx.ext.autodoc",      
-    "sphinx.ext.napoleon",      
-    "sphinx.ext.viewcode",      
-    "sphinx.ext.autosummary",  
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
 ]
 
-autosummary_generate = True  
-templates_path = ['_templates']
+autosummary_generate = True
+templates_path = ["_templates"]
 exclude_patterns = []
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
-
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/epydemix/__init__.py
+++ b/epydemix/__init__.py
@@ -2,8 +2,5 @@
 
 from .model.epimodel import EpiModel, simulate
 from .model.predefined_models import load_predefined_model
-__all__ = [
-    'EpiModel',
-    'simulate',
-    'load_predefined_model'
-]
+
+__all__ = ["EpiModel", "simulate", "load_predefined_model"]

--- a/epydemix/calibration/__init__.py
+++ b/epydemix/calibration/__init__.py
@@ -1,15 +1,7 @@
 # epydemix/calibration/__init__.py
 
-from .metrics import rmse, wmape, ae, mae, mape
-from .calibration_results import CalibrationResults
 from .abc import ABCSampler
+from .calibration_results import CalibrationResults
+from .metrics import ae, mae, mape, rmse, wmape
 
-__all__ = [
-    'rmse',
-    'wmape',
-    'ae',
-    'mae',
-    'mape',
-    'CalibrationResults',
-    'ABCSampler'
-]
+__all__ = ["rmse", "wmape", "ae", "mae", "mape", "CalibrationResults", "ABCSampler"]

--- a/epydemix/calibration/abc.py
+++ b/epydemix/calibration/abc.py
@@ -1,51 +1,56 @@
-from typing import Callable, Dict, Any, Optional, List
 import copy
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, List, Optional
+
 import numpy as np
 import pandas as pd
-from datetime import datetime, timedelta
+
+from ..utils.abc_smc_utils import (
+    DefaultPerturbationContinuous,
+    DefaultPerturbationDiscrete,
+    sample_prior,
+)
 from .calibration_results import CalibrationResults
 from .metrics import rmse
-from ..utils.abc_smc_utils import (
-    DefaultPerturbationContinuous, 
-    DefaultPerturbationDiscrete, 
-    sample_prior
-)
 
 
 class ABCSampler:
     """
     Approximate Bayesian Computation (ABC) class implementing different ABC strategies.
     """
-    def __init__(self, 
-                 simulation_function: Callable,
-                 priors: Dict[str, Any],
-                 parameters: Dict[str, Any],
-                 observed_data: Any,
-                 distance_function: Callable = rmse):
+
+    def __init__(
+        self,
+        simulation_function: Callable,
+        priors: Dict[str, Any],
+        parameters: Dict[str, Any],
+        observed_data: Any,
+        distance_function: Callable = rmse,
+    ):
         """Initialize ABC calibration."""
         self.simulation_function = simulation_function
         self.priors = priors
         self.parameters = parameters.copy()
-        self.observed_data = {'data': observed_data}
+        self.observed_data = {"data": observed_data}
         self.distance_function = distance_function
         self.param_names = list(priors.keys())
-        self.results = None  
-        
-        # Separate continuous and discrete parameters
-        self.continuous_params = [name for name in self.param_names 
-                                if hasattr(priors[name], 'pdf')]
-        self.discrete_params = [name for name in self.param_names 
-                              if name not in self.continuous_params]
+        self.results = None
 
-    def calibrate(self, 
-            strategy: str = "smc",
-            **kwargs) -> CalibrationResults:
+        # Separate continuous and discrete parameters
+        self.continuous_params = [
+            name for name in self.param_names if hasattr(priors[name], "pdf")
+        ]
+        self.discrete_params = [
+            name for name in self.param_names if name not in self.continuous_params
+        ]
+
+    def calibrate(self, strategy: str = "smc", **kwargs) -> CalibrationResults:
         """Run calibration using the specified strategy.
 
         This function allows the user to run Approximate Bayesian Computation (ABC) calibration
-        using one of the available strategies: Sequential Monte Carlo (SMC), rejection sampling, 
-        or top fraction selection. The appropriate method is selected based on the `strategy` 
-        argument, and additional keyword arguments (`**kwargs`) are passed to the corresponding 
+        using one of the available strategies: Sequential Monte Carlo (SMC), rejection sampling,
+        or top fraction selection. The appropriate method is selected based on the `strategy`
+        argument, and additional keyword arguments (`**kwargs`) are passed to the corresponding
         function.
 
         ### Available Strategies:
@@ -54,7 +59,7 @@ class ABCSampler:
         - `"top_fraction"`: Selects the best fraction of simulated results.
 
         ### Arguments:
-        - **strategy** (`str`, default: `"smc"`): 
+        - **strategy** (`str`, default: `"smc"`):
         Specifies the calibration strategy. Must be one of `{"smc", "rejection", "top_fraction"}`.
         - **kwargs**: Additional parameters depending on the chosen strategy.
 
@@ -105,37 +110,45 @@ class ABCSampler:
         strategies = {
             "smc": self.run_smc,
             "rejection": self.run_rejection,
-            "top_fraction": self.run_top_fraction
+            "top_fraction": self.run_top_fraction,
         }
-        
+
         if strategy not in strategies:
-            raise ValueError(f"Unknown strategy: {strategy}. Must be one of {list(strategies.keys())}")
-        
+            raise ValueError(
+                f"Unknown strategy: {strategy}. Must be one of {list(strategies.keys())}"
+            )
+
         self.results = strategies[strategy](**kwargs)
         return copy.deepcopy(self.results)
 
-    def run_smc(self,
-                num_particles: int = 1000,
-                num_generations: int = 10,
-                epsilon_schedule: Optional[List[float]] = None,
-                epsilon_quantile_level: float = 0.5,
-                minimum_epsilon: Optional[float] = None,
-                max_time: Optional[timedelta] = None,
-                total_simulations_budget: Optional[int] = None,
-                perturbations: Optional[Dict[str, Any]] = None, 
-                verbose: bool = True) -> CalibrationResults:
+    def run_smc(
+        self,
+        num_particles: int = 1000,
+        num_generations: int = 10,
+        epsilon_schedule: Optional[List[float]] = None,
+        epsilon_quantile_level: float = 0.5,
+        minimum_epsilon: Optional[float] = None,
+        max_time: Optional[timedelta] = None,
+        total_simulations_budget: Optional[int] = None,
+        perturbations: Optional[Dict[str, Any]] = None,
+        verbose: bool = True,
+    ) -> CalibrationResults:
         """Run ABC-SMC calibration."""
         # Initialize perturbations if not provided
         if perturbations is None:
             perturbations = {
-                param: (DefaultPerturbationContinuous(param) 
-                       if param in self.continuous_params 
-                       else DefaultPerturbationDiscrete(param, self.priors[param]))
+                param: (
+                    DefaultPerturbationContinuous(param)
+                    if param in self.continuous_params
+                    else DefaultPerturbationDiscrete(param, self.priors[param])
+                )
                 for param in self.param_names
             }
 
         if verbose:
-            print(f"Starting ABC-SMC with {num_particles} particles and {num_generations} generations")
+            print(
+                f"Starting ABC-SMC with {num_particles} particles and {num_generations} generations"
+            )
 
         # Run generations
         start_time = datetime.now()
@@ -145,110 +158,142 @@ class ABCSampler:
             start_generation_time = datetime.now()
 
             if gen == 0:
-                epsilon = epsilon_schedule[0] if epsilon_schedule is not None else float('inf')
-                if verbose:
-                    print(f"\nGeneration {gen + 1}/{num_generations} (epsilon: {epsilon:.6f})")
-                # Initialize particles, weights, distances, simulations
-                new_gen = self._initialize_particles(
-                    num_particles, 
-                    epsilon
+                epsilon = (
+                    epsilon_schedule[0]
+                    if epsilon_schedule is not None
+                    else float("inf")
                 )
+                if verbose:
+                    print(
+                        f"\nGeneration {gen + 1}/{num_generations} (epsilon: {epsilon:.6f})"
+                    )
+                # Initialize particles, weights, distances, simulations
+                new_gen = self._initialize_particles(num_particles, epsilon)
                 n_simulations += new_gen["n_simulations"]
 
                 # Store results for generation 0
-                results = self._create_results("smc", 
-                             pd.DataFrame(data={self.param_names[i]: new_gen["particles"][:, i] 
-                                              for i in range(len(self.param_names))}), 
-                             new_gen["weights"], new_gen["distances"], new_gen["simulations"])
-                
+                results = self._create_results(
+                    "smc",
+                    pd.DataFrame(
+                        data={
+                            self.param_names[i]: new_gen["particles"][:, i]
+                            for i in range(len(self.param_names))
+                        }
+                    ),
+                    new_gen["weights"],
+                    new_gen["distances"],
+                    new_gen["simulations"],
+                )
+
                 particles = new_gen["particles"]
                 weights = new_gen["weights"]
                 distances = new_gen["distances"]
-                simulations = new_gen["simulations"]
-                
+
             else:
                 # Compute epsilon for this generation
-                epsilon = (epsilon_schedule[gen] if epsilon_schedule is not None 
-                        else np.quantile(distances, epsilon_quantile_level))
-            
+                epsilon = (
+                    epsilon_schedule[gen]
+                    if epsilon_schedule is not None
+                    else np.quantile(distances, epsilon_quantile_level)
+                )
+
                 if verbose:
-                    print(f"\nGeneration {gen + 1}/{num_generations} (epsilon: {epsilon:.6f})")
-                
+                    print(
+                        f"\nGeneration {gen + 1}/{num_generations} (epsilon: {epsilon:.6f})"
+                    )
+
                 # Update perturbations
                 for perturbation in perturbations.values():
                     perturbation.update(particles, weights, self.param_names)
-                    
+
                 # Run generation
                 new_gen = self._run_smc_generation(
-                    particles, weights, epsilon, 
-                    num_particles, perturbations
+                    particles, weights, epsilon, num_particles, perturbations
                 )
                 n_simulations += new_gen["n_simulations"]
-                
+
                 # Store results
-                results.posterior_distributions[gen] = pd.DataFrame(data={self.param_names[i]: new_gen["particles"][:, i] for i in range(len(self.param_names))})
+                results.posterior_distributions[gen] = pd.DataFrame(
+                    data={
+                        self.param_names[i]: new_gen["particles"][:, i]
+                        for i in range(len(self.param_names))
+                    }
+                )
                 results.distances[gen] = new_gen["distances"]
                 results.weights[gen] = new_gen["weights"]
                 results.selected_trajectories[gen] = new_gen["simulations"]
-                
+
                 # Update current generation
                 particles = new_gen["particles"]
                 weights = new_gen["weights"]
                 distances = new_gen["distances"]
-                simulations = new_gen["simulations"]
 
             if verbose:
                 # Print generation information
                 end_generation_time = datetime.now()
                 elapsed_time = end_generation_time - start_generation_time
                 formatted_time = f"{elapsed_time.seconds // 3600:02}:{(elapsed_time.seconds % 3600) // 60:02}:{elapsed_time.seconds % 60:02}"
-                acceptance_rate = len(new_gen["particles"]) / new_gen["n_simulations"] * 100
-                print(f"\tAccepted {len(new_gen['particles'])}/{new_gen['n_simulations']} (acceptance rate: {acceptance_rate:.2f}%)")
+                acceptance_rate = (
+                    len(new_gen["particles"]) / new_gen["n_simulations"] * 100
+                )
+                print(
+                    f"\tAccepted {len(new_gen['particles'])}/{new_gen['n_simulations']} (acceptance rate: {acceptance_rate:.2f}%)"
+                )
                 print(f"\tElapsed time: {formatted_time}")
 
             # Check stopping conditions
             if self._check_stopping_conditions(
-                epsilon, minimum_epsilon, 
-                start_time, max_time, 
-                n_simulations, total_simulations_budget
+                epsilon,
+                minimum_epsilon,
+                start_time,
+                max_time,
+                n_simulations,
+                total_simulations_budget,
             ):
                 break
-                    
+
         return results
 
-    def run_rejection(self,
-                     epsilon: float = 0.1,
-                     num_particles: int = 1000,
-                     max_time: Optional[timedelta] = None,
-                     total_simulations_budget: Optional[int] = None,
-                     verbose: bool = True, 
-                     progress_update_interval: int = 1000) -> CalibrationResults:
+    def run_rejection(
+        self,
+        epsilon: float = 0.1,
+        num_particles: int = 1000,
+        max_time: Optional[timedelta] = None,
+        total_simulations_budget: Optional[int] = None,
+        verbose: bool = True,
+        progress_update_interval: int = 1000,
+    ) -> CalibrationResults:
         """Run ABC rejection sampling."""
         simulations, distances = [], []
         sampled_params = {p: [] for p in self.param_names}
-        
+
         start_time = datetime.now()
         n_simulations = 0
         last_print = 0  # For tracking progress updates
 
         if verbose:
-            print(f"Starting ABC rejection sampling with {num_particles} particles and epsilon threshold {epsilon}")
-        
+            print(
+                f"Starting ABC rejection sampling with {num_particles} particles and epsilon threshold {epsilon}"
+            )
+
         while len(distances) < num_particles:
             # Check stopping conditions
             if self._check_stopping_conditions(
-                None, None, 
-                start_time, max_time, 
-                n_simulations, total_simulations_budget
+                None,
+                None,
+                start_time,
+                max_time,
+                n_simulations,
+                total_simulations_budget,
             ):
                 break
-                
+
             # Sample and simulate
             params = self._sample_parameters()
             simulation = self._run_simulation(params)
             distance = self.distance_function(self.observed_data, simulation)
             n_simulations += 1
-            
+
             if distance < epsilon:
                 simulations.append(simulation)
                 distances.append(distance)
@@ -256,40 +301,49 @@ class ABCSampler:
                     sampled_params[p].append(params[i])
 
             # Print progress every progress_update_interval simulations if verbose
-            if verbose and n_simulations % progress_update_interval == 0 and n_simulations != last_print:
+            if (
+                verbose
+                and n_simulations % progress_update_interval == 0
+                and n_simulations != last_print
+            ):
                 last_print = n_simulations
                 acceptance_rate = len(distances) / n_simulations * 100
-                print(f"\tSimulations: {n_simulations}, Accepted: {len(distances)}, "
-                      f"Acceptance rate: {acceptance_rate:.2f}%")
-                
+                print(
+                    f"\tSimulations: {n_simulations}, Accepted: {len(distances)}, "
+                    f"Acceptance rate: {acceptance_rate:.2f}%"
+                )
+
         if verbose:
-            print(f"\tFinal: {len(distances)} particles accepted from {n_simulations} simulations "
-                  f"({len(distances)/n_simulations*100:.2f}% acceptance rate)")
-                    
+            print(
+                f"\tFinal: {len(distances)} particles accepted from {n_simulations} simulations "
+                f"({len(distances) / n_simulations * 100:.2f}% acceptance rate)"
+            )
+
         return self._create_results(
             "rejection",
             pd.DataFrame(sampled_params),
             np.ones(len(distances)) / len(distances),
             np.array(distances),
-            simulations
+            simulations,
         )
 
-    def run_top_fraction(self,
-                        top_fraction: float = 0.05,
-                        Nsim: int = 100,
-                        verbose: bool = True) -> CalibrationResults:
+    def run_top_fraction(
+        self, top_fraction: float = 0.05, Nsim: int = 100, verbose: bool = True
+    ) -> CalibrationResults:
         """Run ABC top fraction selection."""
         simulations, distances = [], []
         sampled_params = {p: [] for p in self.param_names}
 
         if verbose:
-            print(f"Starting ABC top fraction selection with {Nsim} simulations and top {top_fraction*100:.1f}% selected")
-        
+            print(
+                f"Starting ABC top fraction selection with {Nsim} simulations and top {top_fraction * 100:.1f}% selected"
+            )
+
         for n in range(Nsim):
             params = self._sample_parameters()
             simulation = self._run_simulation(params)
             distance = self.distance_function(self.observed_data, simulation)
-            
+
             simulations.append(simulation)
             distances.append(distance)
             for i, p in enumerate(self.param_names):
@@ -297,47 +351,55 @@ class ABCSampler:
 
             # Print progress every 10% if verbose
             if verbose and (n + 1) % max(1, Nsim // 10) == 0:
-                print(f"\tProgress: {n + 1}/{Nsim} simulations completed ({(n + 1)/Nsim*100:.1f}%)")
+                print(
+                    f"\tProgress: {n + 1}/{Nsim} simulations completed ({(n + 1) / Nsim * 100:.1f}%)"
+                )
 
         # Select top fraction
         threshold = np.quantile(distances, top_fraction)
         mask = np.array(distances) <= threshold
         n_selected = sum(mask)
-        
+
         if verbose:
-            print(f"\tSelected {n_selected} particles (top {top_fraction*100:.1f}%) "
-                  f"with distance threshold {threshold:.6f}")
+            print(
+                f"\tSelected {n_selected} particles (top {top_fraction * 100:.1f}%) "
+                f"with distance threshold {threshold:.6f}"
+            )
 
         return self._create_results(
             "top_fraction",
             pd.DataFrame(sampled_params)[mask],
             np.ones(sum(mask)) / sum(mask),
             np.array(distances)[mask],
-            np.array(simulations)[mask]
+            np.array(simulations)[mask],
         )
 
     def _run_simulation(self, params: List[float]) -> Dict[str, Any]:
         """Run a single simulation with given parameters."""
-        full_params = {**self.parameters, 
-                       **dict(zip(self.param_names, params))}
+        full_params = {**self.parameters, **dict(zip(self.param_names, params))}
         simulation = self.simulation_function(full_params)
         return self._validate_simulation(simulation)
 
     def _validate_simulation(self, simulation: Any) -> Dict[str, Any]:
         """Ensure simulation output is in correct format."""
         if not isinstance(simulation, dict):
-            raise ValueError(f"Simulation must return dictionary, got {type(simulation)}")
+            raise ValueError(
+                f"Simulation must return dictionary, got {type(simulation)}"
+            )
         return simulation
 
     def _sample_parameters(self) -> List[float]:
         """Sample parameters from priors."""
         return sample_prior(self.priors, self.param_names)
 
-    def _create_results(self, strategy: str, 
-                       particles: pd.DataFrame,
-                       weights: np.ndarray,
-                       distances: np.ndarray,
-                       simulations: List[Dict]) -> CalibrationResults:
+    def _create_results(
+        self,
+        strategy: str,
+        particles: pd.DataFrame,
+        weights: np.ndarray,
+        distances: np.ndarray,
+        simulations: List[Dict],
+    ) -> CalibrationResults:
         """Create CalibrationResults object."""
         return CalibrationResults(
             calibration_strategy=strategy,
@@ -346,16 +408,18 @@ class ABCSampler:
             distances={0: distances},
             weights={0: weights},
             observed_data=self.observed_data,
-            priors=self.priors
+            priors=self.priors,
         )
 
-    def _check_stopping_conditions(self,
-                                 epsilon: Optional[float],
-                                 minimum_epsilon: Optional[float],
-                                 start_time: datetime,
-                                 max_time: Optional[timedelta],
-                                 n_simulations: int,
-                                 total_simulations_budget: Optional[int]) -> bool:
+    def _check_stopping_conditions(
+        self,
+        epsilon: Optional[float],
+        minimum_epsilon: Optional[float],
+        start_time: datetime,
+        max_time: Optional[timedelta],
+        n_simulations: int,
+        total_simulations_budget: Optional[int],
+    ) -> bool:
         """Check if any stopping condition is met."""
         if minimum_epsilon and epsilon and epsilon < minimum_epsilon:
             print("Minimum epsilon reached")
@@ -371,11 +435,11 @@ class ABCSampler:
     def _initialize_particles(self, num_particles, epsilon):
         """
         Initialize the first generation of particles by sampling from priors.
-        
+
         Args:
             num_particles (int): Number of particles to generate
             epsilon (float): Epsilon threshold for initial generation
-            
+
         Returns:
             tuple: (particles, weights, distances, simulations) where
                 - particles: numpy array of shape (num_particles, num_parameters)
@@ -384,39 +448,43 @@ class ABCSampler:
                 - simulations: list of simulation results
         """
         particles, weights, distances, simulations = [], [], [], []
-        
+
         n_simulations = 0
         # Sample from priors and run simulations
         while len(particles) < num_particles:
             params = sample_prior(self.priors, self.param_names)
             full_params = {**self.parameters, **dict(zip(self.param_names, params))}
             simulated_data = self.simulation_function(full_params)
-            dist = self.distance_function(data=self.observed_data, simulation=simulated_data)
+            dist = self.distance_function(
+                data=self.observed_data, simulation=simulated_data
+            )
             n_simulations += 1
-            
+
             if dist <= epsilon:
                 particles.append(params)
                 weights.append(1.0 / num_particles)  # Uniform weights initially
                 distances.append(dist)
                 simulations.append(simulated_data)
-                
+
         return {
             "particles": np.array(particles),
             "weights": np.array(weights),
             "distances": np.array(distances),
             "simulations": simulations,
-            "n_simulations": n_simulations
+            "n_simulations": n_simulations,
         }
 
-    def _run_smc_generation(self,
-                           particles: np.ndarray,
-                           weights: np.ndarray,
-                           epsilon: float,
-                           num_particles: int,
-                           perturbations: Dict[str, Any]) -> Dict[str, Any]:
+    def _run_smc_generation(
+        self,
+        particles: np.ndarray,
+        weights: np.ndarray,
+        epsilon: float,
+        num_particles: int,
+        perturbations: Dict[str, Any],
+    ) -> Dict[str, Any]:
         """Run a single generation of ABC-SMC."""
         new_particles, new_weights, new_distances, new_simulations = [], [], [], []
-        
+
         n_simulations = 0
         for _ in range(num_particles):
             while True:
@@ -426,14 +494,16 @@ class ABCSampler:
 
                 # Propose new parameters (perturbation kernel)
                 perturbed_params = [
-                    perturbations[self.param_names[i]].propose(candidate_params[i]) for i in range(len(self.param_names))
+                    perturbations[self.param_names[i]].propose(candidate_params[i])
+                    for i in range(len(self.param_names))
                 ]
 
                 # Check if perturbed parameters have prior probability > 0
                 prior_probabilities = [
-                  self.priors[param].pdf(perturbed_params[i]) if param in self.continuous_params
-                  else self.priors[param].pmf(perturbed_params[i])
-                  for i, param in enumerate(self.param_names)
+                    self.priors[param].pdf(perturbed_params[i])
+                    if param in self.continuous_params
+                    else self.priors[param].pmf(perturbed_params[i])
+                    for i, param in enumerate(self.param_names)
                 ]
                 if all(prob > 0 for prob in prior_probabilities):
                     simulation = self._run_simulation(perturbed_params)
@@ -442,18 +512,28 @@ class ABCSampler:
 
                     if distance < epsilon:
                         new_particles.append(perturbed_params)
-                        weight_numerator = np.prod([
-                          self.priors[param].pdf(perturbed_params[i]) if param in self.continuous_params
-                          else self.priors[param].pmf(perturbed_params[i])
-                          for i, param in enumerate(self.param_names)
-                        ])
-                        weight_denominator = np.sum([
-                            weights[j] * np.prod([
-                                perturbations[self.param_names[i]].pdf(
-                                    perturbed_params[i], particles[j][i]
-                                ) for i in range(len(self.param_names))
-                            ]) for j in range(len(particles))
-                        ])
+                        weight_numerator = np.prod(
+                            [
+                                self.priors[param].pdf(perturbed_params[i])
+                                if param in self.continuous_params
+                                else self.priors[param].pmf(perturbed_params[i])
+                                for i, param in enumerate(self.param_names)
+                            ]
+                        )
+                        weight_denominator = np.sum(
+                            [
+                                weights[j]
+                                * np.prod(
+                                    [
+                                        perturbations[self.param_names[i]].pdf(
+                                            perturbed_params[i], particles[j][i]
+                                        )
+                                        for i in range(len(self.param_names))
+                                    ]
+                                )
+                                for j in range(len(particles))
+                            ]
+                        )
                         new_weights.append(weight_numerator / weight_denominator)
                         new_distances.append(distance)
                         new_simulations.append(simulation)
@@ -462,20 +542,22 @@ class ABCSampler:
         # Normalize weights
         new_weights = np.array(new_weights)
         new_weights /= new_weights.sum()
-        
+
         return {
             "particles": np.array(new_particles),
             "weights": np.array(new_weights),
             "distances": np.array(new_distances),
             "simulations": new_simulations,
-            "n_simulations": n_simulations
+            "n_simulations": n_simulations,
         }
 
-    def run_projections(self,
-                       parameters: Dict[str, Any],
-                       iterations: int = 100,
-                       generation: Optional[int] = None,
-                       scenario_id: str = "baseline") -> CalibrationResults:
+    def run_projections(
+        self,
+        parameters: Dict[str, Any],
+        iterations: int = 100,
+        generation: Optional[int] = None,
+        scenario_id: str = "baseline",
+    ) -> CalibrationResults:
         """
         Run projections using parameters sampled from the posterior distribution.
 
@@ -488,11 +570,11 @@ class ABCSampler:
         Returns:
             CalibrationResults: A new CalibrationResults object containing the original results plus the new projections
         """
-        
+
         # Get posterior distribution and weights from specified generation
         posterior = self.results.get_posterior_distribution(generation)
         weights = self.results.get_weights(generation)
-        
+
         # Run projections and store results
         projections, posterior_samples = [], {}
         for _ in range(iterations):
@@ -504,7 +586,7 @@ class ABCSampler:
                 if k not in posterior_samples:
                     posterior_samples[k] = []
                 posterior_samples[k].append(posterior_sample[k])
-            
+
             # Prepare and run simulation
             proj_params = parameters.copy()
             proj_params.update(posterior_sample)
@@ -512,6 +594,8 @@ class ABCSampler:
             projections.append(result)
 
         self.results.projections[scenario_id] = projections
-        self.results.projection_parameters[scenario_id] = pd.DataFrame(posterior_samples)
- 
+        self.results.projection_parameters[scenario_id] = pd.DataFrame(
+            posterior_samples
+        )
+
         return copy.deepcopy(self.results)

--- a/epydemix/calibration/calibration_results.py
+++ b/epydemix/calibration/calibration_results.py
@@ -1,8 +1,10 @@
-from dataclasses import dataclass, field
-from typing import List, Dict, Any, Optional
-import pandas as pd
-import numpy as np
 import datetime
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
 
 @dataclass
 class CalibrationResults:
@@ -18,9 +20,10 @@ class CalibrationResults:
         calibration_params: Dictionary of parameters used in calibration
         distances: Dictionary of distances per generation
         weights: Dictionary of weights per generation
-        projections: Dictionary of projections 
-        projection_parameters: Dictionary of projection parameters 
+        projections: Dictionary of projections
+        projection_parameters: Dictionary of projection parameters
     """
+
     calibration_strategy: Optional[str] = None
     posterior_distributions: Dict[int, pd.DataFrame] = field(default_factory=dict)
     selected_trajectories: Dict[int, List[Any]] = field(default_factory=dict)
@@ -29,22 +32,28 @@ class CalibrationResults:
     calibration_params: Dict[str, Any] = field(default_factory=dict)
     distances: Dict[int, List[Any]] = field(default_factory=dict)
     weights: Dict[int, List[Any]] = field(default_factory=dict)
-    projections: Dict[str, List[Any]]= field(default_factory=dict)
+    projections: Dict[str, List[Any]] = field(default_factory=dict)
     projection_parameters: Dict[str, pd.DataFrame] = field(default_factory=dict)
 
-    def _get_generation(self, generation: Optional[int], data_dict: Dict[int, Any]) -> Any:
+    def _get_generation(
+        self, generation: Optional[int], data_dict: Dict[int, Any]
+    ) -> Any:
         """Helper method to get data for a specific generation."""
         generations = list(data_dict.keys())
         if not generations:
             return None
-            
+
         if generation is not None:
             if generation not in generations:
-                raise ValueError(f"Generation {generation} not found, possible generations are {generations}.")
+                raise ValueError(
+                    f"Generation {generation} not found, possible generations are {generations}."
+                )
             return data_dict[generation]
         return data_dict[max(generations)]
 
-    def get_posterior_distribution(self, generation: Optional[int] = None) -> pd.DataFrame:
+    def get_posterior_distribution(
+        self, generation: Optional[int] = None
+    ) -> pd.DataFrame:
         """Gets the posterior distribution DataFrame for a specific generation."""
         return self._get_generation(generation, self.posterior_distributions)
 
@@ -60,58 +69,72 @@ class CalibrationResults:
         """Gets the distances for a specific generation."""
         return self._get_generation(generation, self.distances)
 
-    def get_calibration_trajectories(self, generation: Optional[int] = None) -> Dict[str, np.ndarray]:
+    def get_calibration_trajectories(
+        self, generation: Optional[int] = None
+    ) -> Dict[str, np.ndarray]:
         """Get stacked trajectories from calibration results."""
         simulations = self.get_selected_trajectories(generation)
-        if simulations is None or len(simulations) == 0:  # Better check for empty simulations
+        if (
+            simulations is None or len(simulations) == 0
+        ):  # Better check for empty simulations
             return {}
-        
+
         return {
             key: np.stack([sim[key] for sim in simulations], axis=0)
             for key in simulations[0].keys()
         }
 
-    def get_projection_trajectories(self, scenario_id: str = "baseline") -> Dict[str, np.ndarray]:
+    def get_projection_trajectories(
+        self, scenario_id: str = "baseline"
+    ) -> Dict[str, np.ndarray]:
         """Get stacked trajectories from projection results."""
         if scenario_id not in self.projections:
             raise ValueError(f"No projections found for id {scenario_id}")
-        
+
         simulations = self.projections[scenario_id]
-        if simulations is None or len(simulations) == 0:  # Better check for empty simulations
+        if (
+            simulations is None or len(simulations) == 0
+        ):  # Better check for empty simulations
             return {}
-        
+
         return {
             key: np.stack([sim[key] for sim in simulations], axis=0)
             for key in simulations[0].keys()
         }
 
-    def get_calibration_quantiles(self,
-                                dates: Optional[List[datetime.date]] = None,
-                                quantiles: List[float] = [0.05, 0.5, 0.95],
-                                generation: Optional[int] = None,
-                                variables: Optional[List[str]] = None) -> pd.DataFrame:
+    def get_calibration_quantiles(
+        self,
+        dates: Optional[List[datetime.date]] = None,
+        quantiles: List[float] = [0.05, 0.5, 0.95],
+        generation: Optional[int] = None,
+        variables: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
         """Compute quantiles from calibration results."""
         trajectories = self.get_calibration_trajectories(generation)
         return self._compute_quantiles(trajectories, dates, quantiles, variables)
 
-    def get_projection_quantiles(self,
-                               dates: Optional[List[datetime.date]] = None,
-                               quantiles: List[float] = [0.05, 0.5, 0.95],
-                               scenario_id: str = "baseline",
-                               variables: Optional[List[str]] = None) -> pd.DataFrame:
+    def get_projection_quantiles(
+        self,
+        dates: Optional[List[datetime.date]] = None,
+        quantiles: List[float] = [0.05, 0.5, 0.95],
+        scenario_id: str = "baseline",
+        variables: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
         """Compute quantiles from projection results."""
         trajectories = self.get_projection_trajectories(scenario_id)
         return self._compute_quantiles(trajectories, dates, quantiles, variables)
 
-    def _compute_quantiles(self,
-                         trajectories: Dict[str, np.ndarray],
-                         dates: Optional[List[datetime.date]],
-                         quantiles: List[float],
-                         variables: Optional[List[str]]) -> pd.DataFrame:
+    def _compute_quantiles(
+        self,
+        trajectories: Dict[str, np.ndarray],
+        dates: Optional[List[datetime.date]],
+        quantiles: List[float],
+        variables: Optional[List[str]],
+    ) -> pd.DataFrame:
         """Helper method to compute quantiles from trajectories."""
         if variables:
             trajectories = {k: v for k, v in trajectories.items() if k in variables}
-        
+
         if dates is None:
             dates = np.arange(trajectories[list(trajectories.keys())[0]].shape[1])
 
@@ -121,15 +144,9 @@ class CalibrationResults:
             simulation_dates.extend(dates)
             quantile_values.extend([q] * len(dates))
 
-        data = {
-            "date": simulation_dates,
-            "quantile": quantile_values
-        }
-        
+        data = {"date": simulation_dates, "quantile": quantile_values}
+
         for key, vals in trajectories.items():
-            data[key] = [
-                val for q in quantiles 
-                for val in np.quantile(vals, q, axis=0)
-            ]
+            data[key] = [val for q in quantiles for val in np.quantile(vals, q, axis=0)]
 
         return pd.DataFrame(data)

--- a/epydemix/calibration/metrics.py
+++ b/epydemix/calibration/metrics.py
@@ -1,7 +1,11 @@
-import numpy as np
 from typing import Dict, Tuple
 
-def validate_data(data: Dict, simulation: Dict, shape_check : bool = True) -> Tuple[np.ndarray, np.ndarray]:
+import numpy as np
+
+
+def validate_data(
+    data: Dict, simulation: Dict, shape_check: bool = True
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Validates that the input Dictionaries contain the required key 'data' and that the shapes of the data arrays match.
 
@@ -26,6 +30,7 @@ def validate_data(data: Dict, simulation: Dict, shape_check : bool = True) -> Tu
 
     return observed, simulated
 
+
 def rmse(data: Dict, simulation: Dict) -> float:
     """
     Computes the Root Mean Square Error (RMSE) between the observed data and the simulated data.
@@ -39,6 +44,7 @@ def rmse(data: Dict, simulation: Dict) -> float:
     """
     observed, simulated = validate_data(data, simulation)
     return np.sqrt(np.mean((observed - simulated) ** 2))
+
 
 def wmape(data: Dict, simulation: Dict) -> float:
     """
@@ -54,6 +60,7 @@ def wmape(data: Dict, simulation: Dict) -> float:
     observed, simulated = validate_data(data, simulation)
     return np.sum(np.abs(observed - simulated)) / np.sum(np.abs(observed))
 
+
 def ae(data: Dict, simulation: Dict) -> np.ndarray:
     """
     Computes the Absolute Error (AE) between the observed data and the simulated data.
@@ -68,6 +75,7 @@ def ae(data: Dict, simulation: Dict) -> np.ndarray:
     observed, simulated = validate_data(data, simulation)
     return np.abs(observed - simulated)
 
+
 def mae(data: Dict, simulation: Dict) -> float:
     """
     Computes the Mean Absolute Error (MAE) between the observed data and the simulated data.
@@ -81,6 +89,7 @@ def mae(data: Dict, simulation: Dict) -> float:
     """
     observed, simulated = validate_data(data, simulation)
     return np.mean(np.abs(observed - simulated))
+
 
 def mape(data: Dict, simulation: Dict) -> float:
     """

--- a/epydemix/model/__init__.py
+++ b/epydemix/model/__init__.py
@@ -1,14 +1,14 @@
 # epydemix/model/__init__.py
 
 from .epimodel import EpiModel, simulate
-from .transition import Transition
-from .simulation_results import SimulationResults
 from .predefined_models import load_predefined_model
+from .simulation_results import SimulationResults
+from .transition import Transition
 
 __all__ = [
-    'EpiModel',
-    'simulate',
-    'Transition', 
-    'SimulationResults',
-    'load_predefined_model'
+    "EpiModel",
+    "simulate",
+    "Transition",
+    "SimulationResults",
+    "load_predefined_model",
 ]

--- a/epydemix/model/epimodel.py
+++ b/epydemix/model/epimodel.py
@@ -1,19 +1,29 @@
-from .transition import Transition
-from ..utils.utils import format_simulation_output, create_definitions, apply_overrides, evaluate, compute_simulation_dates, apply_initial_conditions, multinomial
-from .simulation_output import Trajectory
-from .simulation_results import SimulationResults
-import numpy as np 
-import pandas as pd
-from ..population.population import Population, load_epydemix_population
-from typing import List, Dict, Optional, Union, Any, Callable, Tuple
 import copy
 import inspect
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from ..population.population import Population, load_epydemix_population
+from ..utils.utils import (
+    apply_initial_conditions,
+    apply_overrides,
+    compute_simulation_dates,
+    create_definitions,
+    evaluate,
+    format_simulation_output,
+    multinomial,
+)
+from .simulation_output import Trajectory
+from .simulation_results import SimulationResults
+from .transition import Transition
 
 
 class EpiModel:
     """
     EpiModel: A compartmental epidemic model simulator
-    
+
     Example:
         >>> model = EpiModel(compartments=["S", "I", "R"], parameters={"beta": 0.3, "gamma": 0.1})
         >>> model.add_transition(source="S", target="I", params=("beta", "I"))
@@ -25,81 +35,86 @@ class EpiModel:
         ... )
     """
 
-    def __init__(self, 
-                 name : str = "EpiModel",
-                 compartments: Optional[List] = None, 
-                 parameters: Optional[Dict] = None,
-                 population_name: str = "epydemix_population", 
-                 population_data_path: Optional[str] = None, 
-                 contact_layers: Optional[List] = None, 
-                 contacts_source: Optional[str] = None, 
-                 age_group_mapping: Optional[Dict] = None, 
-                 supported_contacts_sources: Optional[List] = None, 
-                 use_default_population: bool = True) -> None:
-            """
-            Initializes the EpiModel instance.
+    def __init__(
+        self,
+        name: str = "EpiModel",
+        compartments: Optional[List] = None,
+        parameters: Optional[Dict] = None,
+        population_name: str = "epydemix_population",
+        population_data_path: Optional[str] = None,
+        contact_layers: Optional[List] = None,
+        contacts_source: Optional[str] = None,
+        age_group_mapping: Optional[Dict] = None,
+        supported_contacts_sources: Optional[List] = None,
+        use_default_population: bool = True,
+    ) -> None:
+        """
+        Initializes the EpiModel instance.
 
-            Args:
-                name (str, optional): The name of the epidemic model. Defaults to "EpiModel".
-                compartments (list, optional): A list of compartments for the model. Defaults to an empty list if None.
-                parameters (dict, optional): A dictionary of parameters for the model. Defaults to an empty dictionary if None.
-                population_name (str, optional): The name of the population to load or create. Defaults to 'epydemix_population'.
-                population_data_path (str or None, optional): The path to the population data.
-                contact_layers (list or None, optional): A list of contact layers to load for the population. Defaults to 
-                    ["school", "work", "home", "community"] if None.
-                contacts_source (str or None, optional): The source of contact data. If None, the function will automatically detect the source.
-                age_group_mapping (dict or None, optional): A mapping of age groups for the population.
-                supported_contacts_sources (list or None, optional): A list of supported contact data sources. Defaults to 
-                    ["prem_2017", "prem_2021", "mistry_2021"] if None.
-                use_default_population (bool, optional): If True, creates a default population; if False, tries to load the population from the provided path and population name. Defaults to True.
-            Returns:
-                None
-            """
-            # Initialize core attributes
-            self.name = name
-            self.transitions = {}
-            self.transitions_list = []
-            self.interventions = []
-            self.compartments = []
-            self.compartments_idx = {}
-            self.transitions_idx = {}
-            self.transition_functions = {}
-            self.parameters = {}
-            self.definitions = {}
-            self.overrides = {}
-            self.Cs = {}
+        Args:
+            name (str, optional): The name of the epidemic model. Defaults to "EpiModel".
+            compartments (list, optional): A list of compartments for the model. Defaults to an empty list if None.
+            parameters (dict, optional): A dictionary of parameters for the model. Defaults to an empty dictionary if None.
+            population_name (str, optional): The name of the population to load or create. Defaults to 'epydemix_population'.
+            population_data_path (str or None, optional): The path to the population data.
+            contact_layers (list or None, optional): A list of contact layers to load for the population. Defaults to
+                ["school", "work", "home", "community"] if None.
+            contacts_source (str or None, optional): The source of contact data. If None, the function will automatically detect the source.
+            age_group_mapping (dict or None, optional): A mapping of age groups for the population.
+            supported_contacts_sources (list or None, optional): A list of supported contact data sources. Defaults to
+                ["prem_2017", "prem_2021", "mistry_2021"] if None.
+            use_default_population (bool, optional): If True, creates a default population; if False, tries to load the population from the provided path and population name. Defaults to True.
+        Returns:
+            None
+        """
+        # Initialize core attributes
+        self.name = name
+        self.transitions = {}
+        self.transitions_list = []
+        self.interventions = []
+        self.compartments = []
+        self.compartments_idx = {}
+        self.transitions_idx = {}
+        self.transition_functions = {}
+        self.parameters = {}
+        self.definitions = {}
+        self.overrides = {}
+        self.Cs = {}
 
-            # Handle default empty lists for compartments and contact layers
-            if compartments is None:
-                compartments = []
-            self.add_compartments(compartments)
-            
-            if contact_layers is None:
-                contact_layers = ["school", "work", "home", "community"]
+        # Handle default empty lists for compartments and contact layers
+        if compartments is None:
+            compartments = []
+        self.add_compartments(compartments)
 
-            # Add parameters if provided
-            if parameters:
-                self.add_parameter(parameters_dict=parameters)
+        if contact_layers is None:
+            contact_layers = ["school", "work", "home", "community"]
 
-            # Handle default contact sources if not provided
-            if supported_contacts_sources is None:
-                supported_contacts_sources = ["prem_2017", "prem_2021", "mistry_2021"]
+        # Add parameters if provided
+        if parameters:
+            self.add_parameter(parameters_dict=parameters)
 
-            # Load or create population based on use_default_population flag
-            self.population = self._load_or_create_population(
-                population_name,
-                population_data_path,
-                contact_layers,
-                contacts_source,
-                age_group_mapping,
-                supported_contacts_sources,
-                use_default_population
-            )
+        # Handle default contact sources if not provided
+        if supported_contacts_sources is None:
+            supported_contacts_sources = ["prem_2017", "prem_2021", "mistry_2021"]
 
-            # Initalize functions to compute transition rates
-            self.register_transition_kind(kind="spontaneous", function=compute_spontaneous_transition_rate)
-            self.register_transition_kind(kind="mediated", function=compute_mediated_transition_rate)
+        # Load or create population based on use_default_population flag
+        self.population = self._load_or_create_population(
+            population_name,
+            population_data_path,
+            contact_layers,
+            contacts_source,
+            age_group_mapping,
+            supported_contacts_sources,
+            use_default_population,
+        )
 
+        # Initalize functions to compute transition rates
+        self.register_transition_kind(
+            kind="spontaneous", function=compute_spontaneous_transition_rate
+        )
+        self.register_transition_kind(
+            kind="mediated", function=compute_mediated_transition_rate
+        )
 
     def __repr__(self) -> str:
         """
@@ -141,19 +156,24 @@ class EpiModel:
         repr_str += f"  Population size: {sum(self.population.Nk)} individuals\n"
         repr_str += f"  Demographic groups: {len(self.population.Nk_names)}\n"
         if len(self.population.Nk_names) > 0:
-            repr_str += "    " + ", ".join([str(name) for name in self.population.Nk_names]) + "\n"
+            repr_str += (
+                "    "
+                + ", ".join([str(name) for name in self.population.Nk_names])
+                + "\n"
+            )
 
         return repr_str
 
-
-    def _load_or_create_population(self, 
-                                population_name: str, 
-                                population_data_path: Optional[str], 
-                                contact_layers: List, 
-                                contacts_source: Optional[str], 
-                                age_group_mapping: Optional[Dict], 
-                                supported_contacts_sources: List, 
-                                use_default_population: bool) -> Population:
+    def _load_or_create_population(
+        self,
+        population_name: str,
+        population_data_path: Optional[str],
+        contact_layers: List,
+        contacts_source: Optional[str],
+        age_group_mapping: Optional[Dict],
+        supported_contacts_sources: List,
+        use_default_population: bool,
+    ) -> Population:
         """
         Loads a population from a file or creates a default population if specified.
 
@@ -164,7 +184,7 @@ class EpiModel:
             contacts_source (str or None): The source of contact data. If None, load_population will auto-determine the source.
             age_group_mapping (dict or None): A mapping for age groups. If None, a default mapping is used.
             supported_contacts_sources (list): A list of supported contact data sources (e.g., "prem_2017", "prem_2021").
-            use_default_population (bool): If True, creates a default population with a single contact matrix and population size of 100000. 
+            use_default_population (bool): If True, creates a default population with a single contact matrix and population size of 100000.
                 If False, attempts to load population data from a local or online source.
 
         Returns:
@@ -173,39 +193,40 @@ class EpiModel:
         if use_default_population:
             # Create a default population manually
             population = Population(name=population_name)
-            population.add_contact_matrix(np.array([[1.]]))  # Default contact matrix
-            population.add_population(np.array([100000]))    # Default population size
+            population.add_contact_matrix(np.array([[1.0]]))  # Default contact matrix
+            population.add_population(np.array([100000]))  # Default population size
             return population
         else:
             # Load population using load_population, which handles both online and local sources
             return load_epydemix_population(
-                population_name, 
-                contacts_source=contacts_source, 
-                path_to_data=population_data_path, 
-                layers=contact_layers, 
-                age_group_mapping=age_group_mapping, 
-                supported_contacts_sources=supported_contacts_sources
+                population_name,
+                contacts_source=contacts_source,
+                path_to_data=population_data_path,
+                layers=contact_layers,
+                age_group_mapping=age_group_mapping,
+                supported_contacts_sources=supported_contacts_sources,
             )
 
-
-    def import_epydemix_population(self, 
-                            population_name: str, 
-                            population_data_path: Optional[str] = None, 
-                            contact_layers: Optional[List] = None, 
-                            contacts_source: Optional[str] = None, 
-                            age_group_mapping: Optional[Dict] = None, 
-                            supported_contacts_sources: Optional[List] = None) -> None:
+    def import_epydemix_population(
+        self,
+        population_name: str,
+        population_data_path: Optional[str] = None,
+        contact_layers: Optional[List] = None,
+        contacts_source: Optional[str] = None,
+        age_group_mapping: Optional[Dict] = None,
+        supported_contacts_sources: Optional[List] = None,
+    ) -> None:
         """
         Sets or updates the population for the model.
 
         Args:
             population_name (str): The name of the population to set.
             population_data_path (str or None, optional): The path to the population data file. If None, data may be fetched online.
-            contact_layers (list or None, optional): A list of contact layers to load for the population. Defaults to 
+            contact_layers (list or None, optional): A list of contact layers to load for the population. Defaults to
                 ["school", "work", "home", "community"] if None.
             contacts_source (str or None, optional): The source of contact data. If None, the function will attempt to determine the source automatically.
             age_group_mapping (dict or None, optional): A mapping for age groups. If None, a default mapping is used.
-            supported_contacts_sources (list or None, optional): A list of supported contact data sources (e.g., "prem_2017", "prem_2021"). 
+            supported_contacts_sources (list or None, optional): A list of supported contact data sources (e.g., "prem_2017", "prem_2021").
                 Defaults to ["prem_2017", "prem_2021", "mistry_2021"] if None.
 
         Returns:
@@ -221,14 +242,13 @@ class EpiModel:
 
         # Load a new population using the same logic as in the constructor
         self.population = load_epydemix_population(
-            population_name, 
-            contacts_source=contacts_source, 
-            path_to_data=population_data_path, 
-            layers=contact_layers, 
-            age_group_mapping=age_group_mapping, 
-            supported_contacts_sources=supported_contacts_sources
+            population_name,
+            contacts_source=contacts_source,
+            path_to_data=population_data_path,
+            layers=contact_layers,
+            age_group_mapping=age_group_mapping,
+            supported_contacts_sources=supported_contacts_sources,
         )
-
 
     def add_compartments(self, compartments: Union[List, object]) -> None:
         """
@@ -252,16 +272,19 @@ class EpiModel:
 
         # Add each compartment with corresponding transitions and index
         for i, compartment in enumerate(compartments, start=1):
-            self.transitions[compartment] = []  # Initialize empty transitions for each compartment
-            self.compartments_idx[compartment] = max_idx + i  # Assign a unique index to each compartment
+            self.transitions[
+                compartment
+            ] = []  # Initialize empty transitions for each compartment
+            self.compartments_idx[compartment] = (
+                max_idx + i
+            )  # Assign a unique index to each compartment
 
     @property
     def n_compartments(self) -> int:
         """Get total number of compartments."""
         return len(self.compartments)
 
-    
-    def clear_compartments(self) -> None: 
+    def clear_compartments(self) -> None:
         """
         This method resets the `compartments` list and clears the `compartments_idx` dictionary.
 
@@ -271,23 +294,24 @@ class EpiModel:
         self.compartments = []
         self.compartments_idx = {}
 
-
-    def add_parameter(self, 
-                    parameter_name: Optional[str] = None, 
-                    value: Any = None, 
-                    parameters_dict: Optional[Dict] = None) -> None:
-        """ 
+    def add_parameter(
+        self,
+        parameter_name: Optional[str] = None,
+        value: Any = None,
+        parameters_dict: Optional[Dict] = None,
+    ) -> None:
+        """
         Adds new parameters to the model.
 
         Args:
             parameter_name (str, optional): The name of the parameter to add. Ignored if `parameters_dict` is provided.
             value (any, optional): The value of the parameter to add. Ignored if `parameters_dict` is provided.
-            parameters_dict (dict, optional): A dictionary of parameter names and values. If provided, 
+            parameters_dict (dict, optional): A dictionary of parameter names and values. If provided,
                 `parameter_name` and `value` are ignored and the parameters are updated using this dictionary.
 
         Raises:
             ValueError: If neither `parameter_name`/`value` nor `parameters_dict` is provided.
-        
+
         Returns:
             None
         """
@@ -296,8 +320,9 @@ class EpiModel:
         elif parameter_name is not None and value is not None:
             self.parameters.update({parameter_name: value})
         else:
-            raise ValueError("Either parameter_name and value or parameters_dict must be provided.")
-
+            raise ValueError(
+                "Either parameter_name and value or parameters_dict must be provided."
+            )
 
     def get_parameter(self, parameter_name: str) -> Any:
         """
@@ -314,7 +339,6 @@ class EpiModel:
         """
         return self.parameters[parameter_name]
 
-
     def delete_parameter(self, parameter_name: str) -> Any:
         """
         Deletes a parameter from the dictionary of the model's parameters.
@@ -330,7 +354,6 @@ class EpiModel:
         """
         return self.parameters.pop(parameter_name)
 
-
     def clear_parameters(self) -> None:
         """
         Clears all parameters from the model's parameters dictionary.
@@ -340,8 +363,9 @@ class EpiModel:
         """
         self.parameters = {}
 
-
-    def override_parameter(self, start_date: str, end_date: str, parameter_name: str, value: Any) -> None:
+    def override_parameter(
+        self, start_date: str, end_date: str, parameter_name: str, value: Any
+    ) -> None:
         """
         Adds an override for a parameter with the specified name.
 
@@ -361,7 +385,6 @@ class EpiModel:
         else:
             self.overrides[parameter_name] = [override_dict]
 
-
     def delete_override(self, parameter_name: str) -> None:
         """
         Deletes overrides for a specific parameter.
@@ -374,7 +397,6 @@ class EpiModel:
         """
         self.overrides.pop(parameter_name, None)
 
-
     def clear_overrides(self) -> None:
         """
         Clears all parameter overrides from the model.
@@ -383,7 +405,6 @@ class EpiModel:
             None
         """
         self.overrides = {}
-
 
     def add_transition(self, source: str, target: str, kind: str, params: Any) -> None:
         """
@@ -401,10 +422,14 @@ class EpiModel:
         Returns:
             None
         """
-        missing_compartments = [comp for comp in [source, target] if comp and comp not in self.compartments]
+        missing_compartments = [
+            comp for comp in [source, target] if comp and comp not in self.compartments
+        ]
         if missing_compartments:
-            raise ValueError(f"These compartments are not in the compartments list: {', '.join(missing_compartments)}")
-        
+            raise ValueError(
+                f"These compartments are not in the compartments list: {', '.join(missing_compartments)}"
+            )
+
         transition = Transition(source=source, target=target, kind=kind, params=params)
         self.transitions_list.append(transition)
         self.transitions[source].append(transition)
@@ -412,7 +437,6 @@ class EpiModel:
         transition_name = f"{source}_to_{target}"
         if transition_name not in self.transitions_idx:
             self.transitions_idx[transition_name] = len(self.transitions_idx)
-
 
     def register_transition_kind(self, kind: str, function: Callable):
         """
@@ -432,13 +456,12 @@ class EpiModel:
     def n_transitions(self) -> int:
         """Get total number of transitions."""
         return len(self.transitions_list)
-        
-    
+
     def clear_transitions(self) -> None:
         """
         Clears all transitions from the model.
 
-        This method resets the `transitions_list` and reinitializes the `transitions` dictionary, 
+        This method resets the `transitions_list` and reinitializes the `transitions` dictionary,
         clearing all existing transitions while keeping the structure intact for each compartment.
 
         Returns:
@@ -447,14 +470,15 @@ class EpiModel:
         self.transitions_list = []
         self.transitions = {comp: [] for comp in self.compartments}
 
-
-    def add_intervention(self, 
-                        layer_name: str, 
-                        start_date: Union[str, pd.Timestamp], 
-                        end_date: Union[str, pd.Timestamp], 
-                        reduction_factor: Optional[float] = None, 
-                        new_matrix: Optional[np.ndarray] = None, 
-                        name: str = "") -> None:
+    def add_intervention(
+        self,
+        layer_name: str,
+        start_date: Union[str, pd.Timestamp],
+        end_date: Union[str, pd.Timestamp],
+        reduction_factor: Optional[float] = None,
+        new_matrix: Optional[np.ndarray] = None,
+        name: str = "",
+    ) -> None:
         """
         Adds an intervention to the epidemic model.
 
@@ -481,16 +505,17 @@ class EpiModel:
             raise ValueError("Either reduction_factor or new_matrix must be provided")
 
         # Append the intervention to the interventions list
-        self.interventions.append({
-            "layer": layer_name, 
-            "start_date": start_date, 
-            "end_date": end_date, 
-            "reduction_factor": reduction_factor, 
-            "new_matrix": new_matrix,
-            "name": name
-        })
+        self.interventions.append(
+            {
+                "layer": layer_name,
+                "start_date": start_date,
+                "end_date": end_date,
+                "reduction_factor": reduction_factor,
+                "new_matrix": new_matrix,
+                "name": name,
+            }
+        )
 
- 
     def clear_interventions(self) -> None:
         """
         Clears all interventions from the model.
@@ -502,8 +527,9 @@ class EpiModel:
         """
         self.interventions = []
 
-
-    def apply_intervention(self, intervention: Dict, simulation_dates: List[pd.Timestamp]) -> None:
+    def apply_intervention(
+        self, intervention: Dict, simulation_dates: List[pd.Timestamp]
+    ) -> None:
         """
         Applies an intervention to the contact matrices for specified simulation dates.
 
@@ -525,9 +551,11 @@ class EpiModel:
         # Early validation of the intervention inputs
         reduction_factor = intervention.get("reduction_factor")
         new_matrix = intervention.get("new_matrix")
-        
+
         if reduction_factor is None and new_matrix is None:
-            raise ValueError("Intervention must have either a reduction_factor or a new_matrix")
+            raise ValueError(
+                "Intervention must have either a reduction_factor or a new_matrix"
+            )
 
         # Extract commonly used values
         layer = intervention["layer"]
@@ -541,24 +569,28 @@ class EpiModel:
             else:  # If reduction_factor is None, we assume new_matrix is provided
                 self.Cs[date][layer] = new_matrix
 
-
     def compute_contact_reductions(self, simulation_dates: List[pd.Timestamp]) -> None:
         """
         Computes the contact reductions for a population over the given simulation dates.
 
-        This function applies interventions to the contact matrices and computes the overall contact matrix 
+        This function applies interventions to the contact matrices and computes the overall contact matrix
         for each date in the simulation period.
 
         Args:
             simulation_dates (list of pd.Timestamp): A list of dates over which the simulation is run.
 
         Returns:
-            None: The function updates the instance variable `self.Cs` with the contact matrices for each date, 
+            None: The function updates the instance variable `self.Cs` with the contact matrices for each date,
                 including the overall contact matrix after applying interventions.
         """
         # Initialize contact matrices for each simulation date, copying the population's initial contact matrices
-        self.Cs = {date: {layer: np.copy(matrix) for layer, matrix in self.population.contact_matrices.items()} 
-                for date in simulation_dates}
+        self.Cs = {
+            date: {
+                layer: np.copy(matrix)
+                for layer, matrix in self.population.contact_matrices.items()
+            }
+            for date in simulation_dates
+        }
 
         # Apply interventions to the contact matrices
         for intervention in self.interventions:
@@ -566,13 +598,16 @@ class EpiModel:
 
         # Compute the overall contact matrix for each date by summing up the contact matrices across layers
         for date in self.Cs:
-            self.Cs[date]["overall"] = np.sum(np.array(list(self.Cs[date].values())), axis=0)
+            self.Cs[date]["overall"] = np.sum(
+                np.array(list(self.Cs[date].values())), axis=0
+            )
 
-
-    def create_default_initial_conditions(self, percentage_in_agents: float = 0.0005) -> Dict[str, np.ndarray]:
+    def create_default_initial_conditions(
+        self, percentage_in_agents: float = 0.0005
+    ) -> Dict[str, np.ndarray]:
         """
-        Creates default initial conditions for the epidemic model. If initial conditions are not provided, 
-        assigns a percentage of the population to agent compartments and the rest to source compartments, 
+        Creates default initial conditions for the epidemic model. If initial conditions are not provided,
+        assigns a percentage of the population to agent compartments and the rest to source compartments,
         considering different age groups.
 
         Args:
@@ -592,39 +627,56 @@ class EpiModel:
         total_population_per_age_group = np.array(population)
 
         # Get compartments that are agents in transitions
-        agent_compartments = [tr.params[1] for tr in self.transitions_list if tr.kind == "mediated"]
-        
+        agent_compartments = [
+            tr.params[1] for tr in self.transitions_list if tr.kind == "mediated"
+        ]
+
         # Get compartments that are sources in transitions with agents
-        source_compartments = [tr.source for tr in self.transitions_list if tr.kind == "mediated"]
+        source_compartments = [
+            tr.source for tr in self.transitions_list if tr.kind == "mediated"
+        ]
 
         # Total number of agent compartments
         num_agent_compartments = len(agent_compartments)
 
         # Distribute population into agent compartments
         if num_agent_compartments > 0:
-            population_in_agents_per_age_group = (total_population_per_age_group * percentage_in_agents).astype(int)
-            population_per_agent_per_age_group = population_in_agents_per_age_group // num_agent_compartments
+            population_in_agents_per_age_group = (
+                total_population_per_age_group * percentage_in_agents
+            ).astype(int)
+            population_per_agent_per_age_group = (
+                population_in_agents_per_age_group // num_agent_compartments
+            )
 
             for comp in agent_compartments:
-                initial_conditions_dict[comp] = population_per_agent_per_age_group.copy()
+                initial_conditions_dict[comp] = (
+                    population_per_agent_per_age_group.copy()
+                )
 
         # Assign the rest of the population to source compartments
-        remaining_population_per_age_group = total_population_per_age_group - np.sum(list(initial_conditions_dict.values()), axis=0)
+        remaining_population_per_age_group = total_population_per_age_group - np.sum(
+            list(initial_conditions_dict.values()), axis=0
+        )
         num_source_compartments = len(source_compartments)
 
         if num_source_compartments > 0:
-            population_per_source_per_age_group = remaining_population_per_age_group // num_source_compartments
+            population_per_source_per_age_group = (
+                remaining_population_per_age_group // num_source_compartments
+            )
 
             for comp in source_compartments:
-                initial_conditions_dict[comp] = population_per_source_per_age_group.copy()
+                initial_conditions_dict[comp] = (
+                    population_per_source_per_age_group.copy()
+                )
 
         # If some compartments are missing, ensure they get zero population
         for comp in self.compartments:
             if comp not in initial_conditions_dict:
-                initial_conditions_dict[comp] = np.zeros_like(total_population_per_age_group)
+                initial_conditions_dict[comp] = np.zeros_like(
+                    total_population_per_age_group
+                )
 
         return initial_conditions_dict
-
 
     def set_population(self, population: Population) -> None:
         """
@@ -637,21 +689,22 @@ class EpiModel:
             None
         """
         self.population = population
-    
 
-    def run_simulations(self, 
-                       start_date: Union[str, pd.Timestamp] = "2020-01-01", 
-                       end_date: Union[str, pd.Timestamp] = "2020-12-31", 
-                       initial_conditions_dict: Optional[Dict[str, np.ndarray]] = None, 
-                       Nsim: int = 100, 
-                       percentage_in_agents: float = 0.0005,
-                       dt: Optional[float] = 1.,
-                       resample_frequency: Optional[str] = "D",
-                       resample_aggregation_compartments: Optional[Union[str, dict]] = "last",
-                       resample_aggregation_transitions: Optional[Union[str, dict]] = "sum",
-                       fill_method: Optional[str] = "ffill", 
-                       apply_linear_approximation: bool = False, 
-                       rng: Optional[np.random.Generator] = None) -> SimulationResults:
+    def run_simulations(
+        self,
+        start_date: Union[str, pd.Timestamp] = "2020-01-01",
+        end_date: Union[str, pd.Timestamp] = "2020-12-31",
+        initial_conditions_dict: Optional[Dict[str, np.ndarray]] = None,
+        Nsim: int = 100,
+        percentage_in_agents: float = 0.0005,
+        dt: Optional[float] = 1.0,
+        resample_frequency: Optional[str] = "D",
+        resample_aggregation_compartments: Optional[Union[str, dict]] = "last",
+        resample_aggregation_transitions: Optional[Union[str, dict]] = "sum",
+        fill_method: Optional[str] = "ffill",
+        apply_linear_approximation: bool = False,
+        rng: Optional[np.random.Generator] = None,
+    ) -> SimulationResults:
         """
         Simulates the epidemic model multiple times over the given time period.
 
@@ -675,7 +728,7 @@ class EpiModel:
         Raises:
             RuntimeError: If the simulation fails.
         """
-        
+
         if rng is None:
             rng = np.random.default_rng()
 
@@ -683,7 +736,9 @@ class EpiModel:
         try:
             # Pre-compute simulation dates, initial conditions, and contact matrices to speed up the simulation
             if initial_conditions_dict is None:
-                initial_conditions_dict = self.create_default_initial_conditions(percentage_in_agents=percentage_in_agents)
+                initial_conditions_dict = self.create_default_initial_conditions(
+                    percentage_in_agents=percentage_in_agents
+                )
             simulation_dates = compute_simulation_dates(start_date, end_date, dt=dt)
             self.compute_contact_reductions(simulation_dates)
             contact_matrices = [self.Cs[date] for date in simulation_dates]
@@ -691,7 +746,7 @@ class EpiModel:
             trajectories = []
             for _ in range(Nsim):
                 trajectory = simulate(
-                    self, 
+                    self,
                     start_date=start_date,
                     end_date=end_date,
                     dt=dt,
@@ -700,38 +755,37 @@ class EpiModel:
                     resample_frequency=resample_frequency,
                     resample_aggregation_compartments=resample_aggregation_compartments,
                     resample_aggregation_transitions=resample_aggregation_transitions,
-                    fill_method=fill_method, 
-                    apply_linear_approximation=apply_linear_approximation, 
-                    rng=rng, 
+                    fill_method=fill_method,
+                    apply_linear_approximation=apply_linear_approximation,
+                    rng=rng,
                     simulation_dates=simulation_dates,
-                    contact_matrices=contact_matrices
+                    contact_matrices=contact_matrices,
                 )
                 trajectories.append(trajectory)
         except Exception as e:
             raise RuntimeError(f"Simulation failed: {str(e)}") from e
 
         # Return SimulationResults with all trajectories
-        return SimulationResults(
-            trajectories=trajectories,
-            parameters=self.parameters
-        )
+        return SimulationResults(trajectories=trajectories, parameters=self.parameters)
 
 
-def simulate(epimodel, 
-             start_date: Union[str, pd.Timestamp] = "2020-01-01", 
-             end_date: Union[str, pd.Timestamp] = "2020-12-31", 
-             initial_conditions_dict: Optional[Dict[str, np.ndarray]] = None, 
-             percentage_in_agents: float = 0.0005,
-             dt: Optional[float] = 1.,
-             resample_frequency: Optional[str] = "D",
-             resample_aggregation_compartments: Optional[Union[str, dict]] = "last",
-             resample_aggregation_transitions: Optional[Union[str, dict]] = "sum",
-             fill_method: Optional[str] = "ffill",
-             apply_linear_approximation: bool = False,
-             rng: Optional[np.random.Generator] = None,
-             contact_matrices: Optional[List[Dict[str, np.ndarray]]] = None,
-             simulation_dates: Optional[List[pd.Timestamp]] = None,
-             **kwargs) -> Trajectory:
+def simulate(
+    epimodel,
+    start_date: Union[str, pd.Timestamp] = "2020-01-01",
+    end_date: Union[str, pd.Timestamp] = "2020-12-31",
+    initial_conditions_dict: Optional[Dict[str, np.ndarray]] = None,
+    percentage_in_agents: float = 0.0005,
+    dt: Optional[float] = 1.0,
+    resample_frequency: Optional[str] = "D",
+    resample_aggregation_compartments: Optional[Union[str, dict]] = "last",
+    resample_aggregation_transitions: Optional[Union[str, dict]] = "sum",
+    fill_method: Optional[str] = "ffill",
+    apply_linear_approximation: bool = False,
+    rng: Optional[np.random.Generator] = None,
+    contact_matrices: Optional[List[Dict[str, np.ndarray]]] = None,
+    simulation_dates: Optional[List[pd.Timestamp]] = None,
+    **kwargs,
+) -> Trajectory:
     """
     Runs a simulation of the epidemic model over the specified simulation dates.
 
@@ -763,16 +817,20 @@ def simulate(epimodel,
 
     # check that the model has transitions
     if len(epimodel.transitions_list) == 0:
-        raise ValueError("The model has no transitions defined. Please add transitions before running simulations.")
-    
+        raise ValueError(
+            "The model has no transitions defined. Please add transitions before running simulations."
+        )
+
     # Compute the simulation dates if not provided
     if simulation_dates is None:
         simulation_dates = compute_simulation_dates(start_date, end_date, dt=dt)
 
     # Compute initial conditions if not provided
     if initial_conditions_dict is None:
-        initial_conditions_dict = epimodel.create_default_initial_conditions(percentage_in_agents=percentage_in_agents)
-        
+        initial_conditions_dict = epimodel.create_default_initial_conditions(
+            percentage_in_agents=percentage_in_agents
+        )
+
     # Compute the contact reductions based on the interventions if not provided
     if contact_matrices is None:
         epimodel.compute_contact_reductions(simulation_dates)
@@ -783,8 +841,12 @@ def simulate(epimodel,
     parameters.update(kwargs)
 
     # Compute the definitions and apply overrides
-    epimodel.definitions = create_definitions(parameters, len(simulation_dates), epimodel.population.Nk.shape[0])
-    epimodel.definitions = apply_overrides(epimodel.definitions, epimodel.overrides, simulation_dates)
+    epimodel.definitions = create_definitions(
+        parameters, len(simulation_dates), epimodel.population.Nk.shape[0]
+    )
+    epimodel.definitions = apply_overrides(
+        epimodel.definitions, epimodel.overrides, simulation_dates
+    )
 
     # Initialize population in different compartments and demographic groups
     initial_conditions = apply_initial_conditions(epimodel, initial_conditions_dict)
@@ -792,46 +854,59 @@ def simulate(epimodel,
     # Run simulation with pre-computed contacts
     compartments_evolution, transitions_evolution = stochastic_simulation(
         T=len(simulation_dates),
-        contact_matrices=contact_matrices,  
+        contact_matrices=contact_matrices,
         epimodel=epimodel,
         parameters=epimodel.definitions,
         initial_conditions=initial_conditions,
-        dt=dt, 
-        apply_linear_approximation=apply_linear_approximation, 
-        rng=rng
+        dt=dt,
+        apply_linear_approximation=apply_linear_approximation,
+        rng=rng,
     )
 
     # Format the simulation output
-    results = format_simulation_output(compartments_evolution, transitions_evolution, 
-                                       epimodel.compartments_idx, epimodel.transitions_idx, 
-                                       epimodel.population.Nk_names)
-    trajectory = Trajectory(compartments=results["compartments"], transitions=results["transitions"], 
-                            dates=simulation_dates, compartment_idx=epimodel.compartments_idx, 
-                            transitions_idx=epimodel.transitions_idx, parameters=epimodel.definitions)
+    results = format_simulation_output(
+        compartments_evolution,
+        transitions_evolution,
+        epimodel.compartments_idx,
+        epimodel.transitions_idx,
+        epimodel.population.Nk_names,
+    )
+    trajectory = Trajectory(
+        compartments=results["compartments"],
+        transitions=results["transitions"],
+        dates=simulation_dates,
+        compartment_idx=epimodel.compartments_idx,
+        transitions_idx=epimodel.transitions_idx,
+        parameters=epimodel.definitions,
+    )
 
     # Only resample if necessary
     if resample_frequency is not None:
         # Check if resampling is needed (simulation dates frequency != requested frequency)
         sim_freq = pd.infer_freq(simulation_dates)
         if sim_freq != resample_frequency:
-            trajectory.resample(resample_frequency, 
-                                resample_aggregation_compartments, 
-                                resample_aggregation_transitions, 
-                                fill_method)
+            trajectory.resample(
+                resample_frequency,
+                resample_aggregation_compartments,
+                resample_aggregation_transitions,
+                fill_method,
+            )
     return trajectory
 
 
-def stochastic_simulation(T: int,
-                         contact_matrices: List[Dict[str, np.ndarray]],
-                         epimodel,
-                         parameters: Dict,
-                         initial_conditions: np.ndarray,
-                         dt: float, 
-                         apply_linear_approximation: bool = False, 
-                         rng: Optional[np.random.Generator] = None) -> np.ndarray:
+def stochastic_simulation(
+    T: int,
+    contact_matrices: List[Dict[str, np.ndarray]],
+    epimodel,
+    parameters: Dict,
+    initial_conditions: np.ndarray,
+    dt: float,
+    apply_linear_approximation: bool = False,
+    rng: Optional[np.random.Generator] = None,
+) -> np.ndarray:
     """
     Run a stochastic simulation of the epidemic model.
-    
+
     Args:
         T: Number of time steps
         contact_matrices: Pre-computed list of contact matrices dictionaries (key is the layer, value is the contact matrix)
@@ -848,15 +923,15 @@ def stochastic_simulation(T: int,
     # Pre-allocate arrays
     N = len(epimodel.population.Nk)
     C = len(epimodel.compartments)
-    
+
     compartments_evolution = np.zeros((T + 1, C, N), dtype=np.float64)
     transitions_evolution = np.zeros((T, epimodel.n_transitions, N), dtype=np.float64)
     compartments_evolution[0] = initial_conditions
-    
+
     # Pre-compute population sizes and create views for better performance
     pop_sizes = epimodel.population.Nk
     comp_indices = epimodel.compartments_idx
-    
+
     # Pre-allocate arrays for rates and transitions
     rates = np.zeros((C, N), dtype=np.float64)
     new_pop = np.zeros((C, N), dtype=np.float64)
@@ -864,31 +939,33 @@ def stochastic_simulation(T: int,
 
     # create a dictionary to store the data needed for the transitions
     system_data = {
-        "parameters": parameters, 
+        "parameters": parameters,
         "t": 0,
         "comp_indices": comp_indices,
         "contact_matrix": None,
         "pop": None,
         "pop_sizes": pop_sizes,
-        "dt": dt
-        }
-    
+        "dt": dt,
+    }
+
     # Simulate each time step
     for t in range(T):
         # Update system data with current state
-        system_data.update({
-            "t": t,
-            "contact_matrix": contact_matrices[t],
-            "pop": compartments_evolution[t]
-        })
+        system_data.update(
+            {
+                "t": t,
+                "contact_matrix": contact_matrices[t],
+                "pop": compartments_evolution[t],
+            }
+        )
 
         new_pop[:] = compartments_evolution[t]
-        
+
         for comp in epimodel.compartments:
             transitions = epimodel.transitions[comp]
-            if not transitions: 
+            if not transitions:
                 continue
-                
+
             rates.fill(0)
             source_idx = comp_indices[comp]
             current_pop = compartments_evolution[t, source_idx]
@@ -903,34 +980,51 @@ def stochastic_simulation(T: int,
                     tr.params, system_data
                 )
                 rates[target_idx] += trans_rate
-            
-            delta = np.array([
-                multinomial(n, r, source_idx, mask, dt, apply_linear_approximation=apply_linear_approximation, rng=rng, probs_out=probs_out) if n > 0 else np.zeros(C)
-                for n, r in zip(current_pop, rates.T)
-            ])
+
+            delta = np.array(
+                [
+                    multinomial(
+                        n,
+                        r,
+                        source_idx,
+                        mask,
+                        dt,
+                        apply_linear_approximation=apply_linear_approximation,
+                        rng=rng,
+                        probs_out=probs_out,
+                    )
+                    if n > 0
+                    else np.zeros(C)
+                    for n, r in zip(current_pop, rates.T)
+                ]
+            )
 
             # Store transition counts
             for tr in transitions:
                 tr_name = f"{tr.source}_to_{tr.target}"
                 tr_idx = epimodel.transitions_idx[tr_name]
-                transitions_evolution[t, tr_idx] += delta[:, epimodel.compartments_idx[tr.target]]
-            
+                transitions_evolution[t, tr_idx] += delta[
+                    :, epimodel.compartments_idx[tr.target]
+                ]
+
             # Update populations
-            np.subtract(new_pop[source_idx], np.sum(delta, axis=1), out=new_pop[source_idx])
+            np.subtract(
+                new_pop[source_idx], np.sum(delta, axis=1), out=new_pop[source_idx]
+            )
             new_pop += delta.T
-        
+
         compartments_evolution[t + 1] = new_pop
-    
+
     return compartments_evolution[1:], transitions_evolution
 
 
-def compute_spontaneous_transition_rate(params, data): 
+def compute_spontaneous_transition_rate(params, data):
     """
     Compute the rate of a spontaneous transition.
 
     Args:
         params: The parameters of the transition provided by the user.
-        data: A dictionary containing the data needed for the transition. 
+        data: A dictionary containing the data needed for the transition.
             - parameters: The model parameters
             - t: The current time step
     Returns:
@@ -944,13 +1038,13 @@ def compute_spontaneous_transition_rate(params, data):
         return params
 
 
-def compute_mediated_transition_rate(params, data): 
+def compute_mediated_transition_rate(params, data):
     """
     Compute the rate of a mediated transition.
 
     Args:
         params: The parameters of the transition provided by the user.
-        data: A dictionary containing the data needed for the transition. 
+        data: A dictionary containing the data needed for the transition.
             - parameters: The model parameters
             - t: The current time step
             - comp_indices: The indices of the compartments
@@ -961,42 +1055,41 @@ def compute_mediated_transition_rate(params, data):
     if isinstance(params[0], str):
         env_copy = copy.deepcopy(data["parameters"])
         rate_eval = evaluate(expr=params[0], env=env_copy)[data["t"]]
-    else: 
+    else:
         rate_eval = params[0]
     agent_idx = data["comp_indices"][params[1]]
     interaction = np.sum(
-            data["contact_matrix"]["overall"] * data["pop"][agent_idx] / data["pop_sizes"], 
-            axis=1
-        )
+        data["contact_matrix"]["overall"] * data["pop"][agent_idx] / data["pop_sizes"],
+        axis=1,
+    )
     return rate_eval * interaction
 
 
 def validate_transition_function(func: Callable) -> None:
     """
     Validates that a transition rate function has the correct signature and parameters.
-    
+
     Args:
         func: The transition rate function to validate
-        
+
     Raises:
         ValueError: If the function signature doesn't match requirements
     """
     # Get function signature
     sig = inspect.signature(func)
     params = sig.parameters
-    
+
     # Check number of parameters
     if len(params) != 2:
         raise ValueError(
             f"Transition function must take exactly 2 parameters. Got {len(params)}: {list(params.keys())}"
         )
-    
+
     # Check parameter names
-    expected_params = ['params', 'data']
+    expected_params = ["params", "data"]
     actual_params = list(params.keys())
-    
+
     if actual_params != expected_params:
         raise ValueError(
             f"Transition function must have parameters named {expected_params}. Got {actual_params}"
         )
-    

--- a/epydemix/model/predefined_models.py
+++ b/epydemix/model/predefined_models.py
@@ -2,55 +2,116 @@ from .epimodel import EpiModel
 
 SUPPORTED_MODELS = ["SIR", "SEIR", "SIS"]
 
-def load_predefined_model(model_name: str, transmission_rate: float = 0.3, recovery_rate: float = 0.1, incubation_rate : float = 0.2) -> None:
-        """
-        Loads a predefined epidemic model (e.g., SIR, SEIR, SIS) with predefined compartments and transitions.
 
-        Args:
-            model_name (str): The name of the predefined model to load (e.g., "SIR").
-            transmission_rate (float, optional): The transmission rate for the SIR model. Default is 0.3.
-            recovery_rate (float, optional): The recovery rate for the SIR model. Default is 0.1.
-            incubation_rate (float, optional): The incubation rate for the SEIR model. Default is 0.2.
-        
-        Raises:
-            ValueError: If the model_name is not recognized.
-        """
-        if model_name == "SIR":
-            return create_sir(transmission_rate, recovery_rate)
+def load_predefined_model(
+    model_name: str,
+    transmission_rate: float = 0.3,
+    recovery_rate: float = 0.1,
+    incubation_rate: float = 0.2,
+) -> None:
+    """
+    Loads a predefined epidemic model (e.g., SIR, SEIR, SIS) with predefined compartments and transitions.
 
-        elif model_name == "SEIR":
-            return create_seir(transmission_rate, incubation_rate, recovery_rate)
+    Args:
+        model_name (str): The name of the predefined model to load (e.g., "SIR").
+        transmission_rate (float, optional): The transmission rate for the SIR model. Default is 0.3.
+        recovery_rate (float, optional): The recovery rate for the SIR model. Default is 0.1.
+        incubation_rate (float, optional): The incubation rate for the SEIR model. Default is 0.2.
 
-        elif model_name == "SIS":
-            return create_sis(transmission_rate, recovery_rate)
+    Raises:
+        ValueError: If the model_name is not recognized.
+    """
+    if model_name == "SIR":
+        return create_sir(transmission_rate, recovery_rate)
 
-        else:
-            raise ValueError(f"Unknown predefined model: {model_name}, supported models are: {SUPPORTED_MODELS}")
-        
+    elif model_name == "SEIR":
+        return create_seir(transmission_rate, incubation_rate, recovery_rate)
+
+    elif model_name == "SIS":
+        return create_sis(transmission_rate, recovery_rate)
+
+    else:
+        raise ValueError(
+            f"Unknown predefined model: {model_name}, supported models are: {SUPPORTED_MODELS}"
+        )
+
 
 def create_sir(transmission_rate: float, recovery_rate: float) -> EpiModel:
     """Create a SIR model with the given transmission rate and recovery rate."""
-    model = EpiModel(compartments=["Susceptible", "Infected", "Recovered"], 
-                     parameters={"transmission_rate": transmission_rate, "recovery_rate": recovery_rate})
-    model.add_transition(source="Susceptible", target="Infected", params=("transmission_rate", "Infected"), kind="mediated")
-    model.add_transition(source="Infected", target="Recovered", params="recovery_rate", kind="spontaneous" )
+    model = EpiModel(
+        compartments=["Susceptible", "Infected", "Recovered"],
+        parameters={
+            "transmission_rate": transmission_rate,
+            "recovery_rate": recovery_rate,
+        },
+    )
+    model.add_transition(
+        source="Susceptible",
+        target="Infected",
+        params=("transmission_rate", "Infected"),
+        kind="mediated",
+    )
+    model.add_transition(
+        source="Infected",
+        target="Recovered",
+        params="recovery_rate",
+        kind="spontaneous",
+    )
     return model
 
 
-def create_seir(transmission_rate: float, incubation_rate: float, recovery_rate: float) -> EpiModel:
+def create_seir(
+    transmission_rate: float, incubation_rate: float, recovery_rate: float
+) -> EpiModel:
     """Create a SEIR model with the given transmission rate, incubation rate, and recovery rate."""
-    model = EpiModel(compartments=["Susceptible", "Exposed", "Infected", "Recovered"], 
-                     parameters={"transmission_rate": transmission_rate, "incubation_rate": incubation_rate, "recovery_rate": recovery_rate})
-    model.add_transition(source="Susceptible", target="Exposed", params=("transmission_rate", "Infected"), kind="mediated")
-    model.add_transition(source="Exposed", target="Infected", params="incubation_rate", kind="spontaneous") 
-    model.add_transition(source="Infected", target="Recovered", params="recovery_rate", kind="spontaneous")
+    model = EpiModel(
+        compartments=["Susceptible", "Exposed", "Infected", "Recovered"],
+        parameters={
+            "transmission_rate": transmission_rate,
+            "incubation_rate": incubation_rate,
+            "recovery_rate": recovery_rate,
+        },
+    )
+    model.add_transition(
+        source="Susceptible",
+        target="Exposed",
+        params=("transmission_rate", "Infected"),
+        kind="mediated",
+    )
+    model.add_transition(
+        source="Exposed",
+        target="Infected",
+        params="incubation_rate",
+        kind="spontaneous",
+    )
+    model.add_transition(
+        source="Infected",
+        target="Recovered",
+        params="recovery_rate",
+        kind="spontaneous",
+    )
     return model
 
 
 def create_sis(transmission_rate: float, recovery_rate: float) -> EpiModel:
     """Create a SIS model with the given transmission rate and recovery rate."""
-    model = EpiModel(compartments=["Susceptible", "Infected"], 
-                     parameters={"transmission_rate": transmission_rate, "recovery_rate": recovery_rate})
-    model.add_transition(source="Susceptible", target="Infected", params=("transmission_rate", "Infected"), kind="mediated")
-    model.add_transition(source="Infected", target="Susceptible", params="recovery_rate", kind="spontaneous")
+    model = EpiModel(
+        compartments=["Susceptible", "Infected"],
+        parameters={
+            "transmission_rate": transmission_rate,
+            "recovery_rate": recovery_rate,
+        },
+    )
+    model.add_transition(
+        source="Susceptible",
+        target="Infected",
+        params=("transmission_rate", "Infected"),
+        kind="mediated",
+    )
+    model.add_transition(
+        source="Infected",
+        target="Susceptible",
+        params="recovery_rate",
+        kind="spontaneous",
+    )
     return model

--- a/epydemix/model/simulation_output.py
+++ b/epydemix/model/simulation_output.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
-from typing import Dict, List, Any
-import pandas as pd
+from typing import Any, Dict, List
+
 import numpy as np
+import pandas as pd
+
 
 @dataclass
 class Trajectory:
     """
     Class to store a single trajectory data.
-    
+
     Attributes:
         compartments (Dict[str, np.ndarray]): Dictionary mapping compartment names to arrays of shape (timesteps,)
         transitions (Dict[str, np.ndarray]): Dictionary mapping transition names to arrays of shape (timesteps,)
@@ -16,6 +18,7 @@ class Trajectory:
         transitions_idx (Dict[str, int]): Dictionary mapping transition names to indices
         parameters (Dict[str, Any]): Dictionary of parameters used in the simulation
     """
+
     compartments: Dict[str, np.ndarray]
     transitions: Dict[str, np.ndarray]
     dates: List[pd.Timestamp]
@@ -23,10 +26,16 @@ class Trajectory:
     transitions_idx: Dict[str, int]
     parameters: Dict[str, Any]
 
-    def resample(self, freq: str, method_compartments: str = 'last', method_transitions: str = 'sum', fill_method: str = 'ffill') -> None:
+    def resample(
+        self,
+        freq: str,
+        method_compartments: str = "last",
+        method_transitions: str = "sum",
+        fill_method: str = "ffill",
+    ) -> None:
         """
         Resample trajectory to new frequency.
-        
+
         Args:
             freq (str): Frequency for resampling (e.g., 'D' for daily, 'W' for weekly)
             method_compartments (str): Aggregation method for compartments. Default is 'last'
@@ -36,35 +45,37 @@ class Trajectory:
                 - 'bfill': Backward fill (use next valid observation)
                 - 'interpolate': Linear interpolation between points
                 Default is 'ffill'.
-                    
+
         Raises:
             ValueError: If fill_method is not one of ['ffill', 'bfill', 'interpolate']
         """
-        if fill_method not in ['ffill', 'bfill', 'interpolate']:
-            raise ValueError("fill_method must be one of ['ffill', 'bfill', 'interpolate']")
+        if fill_method not in ["ffill", "bfill", "interpolate"]:
+            raise ValueError(
+                "fill_method must be one of ['ffill', 'bfill', 'interpolate']"
+            )
 
         # Resample compartments
         df_comp = pd.DataFrame(self.compartments, index=self.dates)
         df_comp_resampled = df_comp.resample(freq).agg(method_compartments)
-        
+
         # Resample transitions
         df_trans = pd.DataFrame(self.transitions, index=self.dates)
         df_trans_resampled = df_trans.resample(freq).agg(method_transitions)
-        
+
         # Handle NaN values
-        if fill_method == 'interpolate':
-            df_comp_resampled = df_comp_resampled.interpolate(method='linear')
+        if fill_method == "interpolate":
+            df_comp_resampled = df_comp_resampled.interpolate(method="linear")
             # Handle edge cases
             df_comp_resampled = df_comp_resampled.ffill().bfill()
             df_trans_resampled = df_trans_resampled.fillna(0)
         else:
-            if fill_method == 'ffill':
+            if fill_method == "ffill":
                 df_comp_resampled = df_comp_resampled.ffill()
-            else: 
+            else:
                 df_comp_resampled = df_comp_resampled.bfill()
             df_trans_resampled = df_trans_resampled.fillna(0)
 
-        # Update 
+        # Update
         self.compartments = {k: np.array(v) for k, v in df_comp_resampled.items()}
         self.transitions = {k: np.array(v) for k, v in df_trans_resampled.items()}
         self.dates = df_comp_resampled.index.tolist()

--- a/epydemix/model/transition.py
+++ b/epydemix/model/transition.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+
 class Transition:
     """
     Represents a transition in an epidemic model.

--- a/epydemix/population/__init__.py
+++ b/epydemix/population/__init__.py
@@ -1,11 +1,5 @@
 # epydemix/population/__init__.py
 
-from .population import Population, load_epydemix_population, get_available_locations
+from .population import Population, get_available_locations, load_epydemix_population
 
-
-__all__ = [
-    'Population', 
-    'load_epydemix_population',
-    'get_available_locations'
-]
-
+__all__ = ["Population", "load_epydemix_population", "get_available_locations"]

--- a/epydemix/population/population.py
+++ b/epydemix/population/population.py
@@ -1,75 +1,81 @@
-import numpy as np 
-import pandas as pd
-import os 
+import os
 from collections import OrderedDict
-from typing import List, Dict, Optional
 from pathlib import Path
+from typing import Dict, List, Optional
 
-demographic_grouping_prem = OrderedDict({
-    "0-4": np.arange(0, 5).astype(str), 
-    "5-9": np.arange(5, 10).astype(str),
-    "10-14": np.arange(10, 15).astype(str),
-    "15-19": np.arange(15, 20).astype(str),
-    "20-24": np.arange(20, 25).astype(str),
-    "25-29": np.arange(25, 30).astype(str),
-    "30-34": np.arange(30, 35).astype(str),
-    "35-39": np.arange(35, 40).astype(str),
-    "40-44": np.arange(40, 45).astype(str),
-    "45-49": np.arange(45, 50).astype(str),
-    "50-54": np.arange(50, 55).astype(str),
-    "55-59": np.arange(55, 60).astype(str),
-    "60-64": np.arange(60, 65).astype(str),
-    "65-69": np.arange(65, 70).astype(str),
-    "70-74": np.arange(70, 75).astype(str),
-    "75+": np.concatenate((np.arange(75, 84), ["84+"])).astype(str)})
+import numpy as np
+import pandas as pd
+
+demographic_grouping_prem = OrderedDict(
+    {
+        "0-4": np.arange(0, 5).astype(str),
+        "5-9": np.arange(5, 10).astype(str),
+        "10-14": np.arange(10, 15).astype(str),
+        "15-19": np.arange(15, 20).astype(str),
+        "20-24": np.arange(20, 25).astype(str),
+        "25-29": np.arange(25, 30).astype(str),
+        "30-34": np.arange(30, 35).astype(str),
+        "35-39": np.arange(35, 40).astype(str),
+        "40-44": np.arange(40, 45).astype(str),
+        "45-49": np.arange(45, 50).astype(str),
+        "50-54": np.arange(50, 55).astype(str),
+        "55-59": np.arange(55, 60).astype(str),
+        "60-64": np.arange(60, 65).astype(str),
+        "65-69": np.arange(65, 70).astype(str),
+        "70-74": np.arange(70, 75).astype(str),
+        "75+": np.concatenate((np.arange(75, 84), ["84+"])).astype(str),
+    }
+)
 
 contacts_age_group_mapping_prem = {
-    "0-4": ["0-4"], 
-    "5-19": ["5-9", "10-14", "15-19"], 
-    "20-49": ["20-24", "25-29", "30-34", "35-39", "40-44", "45-49"], 
+    "0-4": ["0-4"],
+    "5-19": ["5-9", "10-14", "15-19"],
+    "20-49": ["20-24", "25-29", "30-34", "35-39", "40-44", "45-49"],
     "50-64": ["50-54", "55-59", "60-64"],
-    "65+": ["65-69", "70-74", "75+"]}
+    "65+": ["65-69", "70-74", "75+"],
+}
 
 contacts_age_group_mapping_mistry = {
     "0-4": np.arange(0, 5).astype(str),
-    "5-19": np.arange(5, 20).astype(str), 
-    "20-49": np.arange(20, 50).astype(str), 
+    "5-19": np.arange(5, 20).astype(str),
+    "20-49": np.arange(20, 50).astype(str),
     "50-64": np.arange(50, 65).astype(str),
-    "65+": np.concatenate((np.arange(65, 84).astype(str), ["84+"]))}
+    "65+": np.concatenate((np.arange(65, 84).astype(str), ["84+"])),
+}
 
 
 class Population:
     """
-    Represents a population for epidemiological modeling, including demographic data and contact matrices.
+     Represents a population for epidemiological modeling, including demographic data and contact matrices.
 
-    The `Population` class manages and stores population data, including demographic distributions and contact matrices 
-    for various layers (e.g., school, work, home, community). It provides methods to add and retrieve this data for use 
-    in simulations and analysis.
+     The `Population` class manages and stores population data, including demographic distributions and contact matrices
+     for various layers (e.g., school, work, home, community). It provides methods to add and retrieve this data for use
+     in simulations and analysis.
 
-    Attributes:
-        name (str): The name of the population.
-        Nk (List): List representing population data for different demographic groups.
-        Nk_names (List[str]): List of demographic group names.
-        contact_matrices (Dict[str, np.ndarray]): Dictionary mapping layer names to their corresponding contact matrices 
-            (aggregated by age groups).
-    
-   Example 1: Online import (data will be fetched from GitHub)
-    population_online = load_epydemix_population(
-        population_name="United_States",
-        # Specify the preferred contact data source (needed only if you want to override the default primary source)
-        contacts_source="mistry_2021",  
-        layers=["home", "work", "school", "community"]  # Load contact layers (by default all layers are imported)
-    )
+     Attributes:
+         name (str): The name of the population.
+         Nk (List): List representing population data for different demographic groups.
+         Nk_names (List[str]): List of demographic group names.
+         contact_matrices (Dict[str, np.ndarray]): Dictionary mapping layer names to their corresponding contact matrices
+             (aggregated by age groups).
 
-    Example 2: Offline import (data will be loaded from a local directory)
-    # Ensure that the folder is downloaded locally before running this
-    population_offline = load_epydemix_population(
-        population_name="United_States",
-        path_to_data="path/to/local/epydemix_data/",  # Path to the local data folder
-        # Specify the preferred contact data source (needed only if you want to override the default primary source)
-        contacts_source="mistry_2021", 
-        layers=["home", "work", "school", "community"]  # Load contact layers (by default all layers are imported)
-    )
+    Example 1: Online import (data will be fetched from GitHub)
+     population_online = load_epydemix_population(
+         population_name="United_States",
+         # Specify the preferred contact data source (needed only if you want to override the default primary source)
+         contacts_source="mistry_2021",
+         layers=["home", "work", "school", "community"]  # Load contact layers (by default all layers are imported)
+     )
+
+     Example 2: Offline import (data will be loaded from a local directory)
+     # Ensure that the folder is downloaded locally before running this
+     population_offline = load_epydemix_population(
+         population_name="United_States",
+         path_to_data="path/to/local/epydemix_data/",  # Path to the local data folder
+         # Specify the preferred contact data source (needed only if you want to override the default primary source)
+         contacts_source="mistry_2021",
+         layers=["home", "work", "school", "community"]  # Load contact layers (by default all layers are imported)
+     )
     """
 
     def __init__(self, name: str = "population") -> None:
@@ -78,7 +84,7 @@ class Population:
 
         Args:
             name (str, optional): Name of the population object. Defaults to "population".
-        
+
         Attributes:
             name (str): Name of the population.
             contact_matrices (Dict[str, np.ndarray]): Dictionary to hold contact matrices for different layers.
@@ -87,23 +93,22 @@ class Population:
         """
         self.name = name
         self.contact_matrices = {}  # Dictionary of contact matrices for different layers
-        self.Nk = []                # Population data
-        self.Nk_names = []          # List of demographic group names
-
+        self.Nk = []  # Population data
+        self.Nk_names = []  # List of demographic group names
 
     def __repr__(self) -> str:
         """
-        Returns a string representation of the Population object, 
-        summarizing its key attributes such as the name, number of demographic groups, 
+        Returns a string representation of the Population object,
+        summarizing its key attributes such as the name, number of demographic groups,
         and number of contact matrices.
-        
+
         Returns:
             str: String representation of the Population object.
         """
         # General population info
         repr_str = f"Population(name='{self.name}')\n"
         repr_str += f"Demographic groups: {len(self.Nk)} groups\n"
-        
+
         # Population group names and sizes if available
         if len(self.Nk) > 0 and len(self.Nk_names) > 0:
             repr_str += "Population distribution:\n"
@@ -111,7 +116,7 @@ class Population:
                 repr_str += f"  - {name}: {size} individuals\n"
         else:
             repr_str += "Population data not available\n"
-        
+
         # Contact matrices summary
         repr_str += f"Contact matrices: {len(self.contact_matrices)} layers\n"
         if len(self.contact_matrices) > 0:
@@ -120,23 +125,24 @@ class Population:
                 repr_str += f"  - {layer}\n"
         else:
             repr_str += "No contact matrices available\n"
-        
+
         return repr_str
 
-    
-    def add_contact_matrix(self, contact_matrix: np.ndarray, layer_name: str = "all") -> None:
+    def add_contact_matrix(
+        self, contact_matrix: np.ndarray, layer_name: str = "all"
+    ) -> None:
         """
         Adds a contact matrix for a specified layer.
 
         Args:
-            contact_matrix (np.ndarray): The contact matrix to be added, representing contact patterns 
+            contact_matrix (np.ndarray): The contact matrix to be added, representing contact patterns
                 between different demographic groups.
-            layer_name (str, optional): The name of the contact layer (e.g., "home", "work"). 
+            layer_name (str, optional): The name of the contact layer (e.g., "home", "work").
                 Defaults to "all". Cannot be "overall" as it's reserved.
-        
+
         Raises:
             ValueError: If contact_matrix is not a 2D square array or if layer_name is "overall"
-        
+
         Returns:
             None
         """
@@ -144,30 +150,32 @@ class Population:
         if layer_name == "overall":
             raise ValueError(
                 '"overall" is a reserved layer name used for total contacts. '
-                'Please use a different name for this layer.'
+                "Please use a different name for this layer."
             )
-        
+
         # Cast contact_matrix to a numpy array
         contact_matrix = np.array(contact_matrix)
 
         # Check that contact_matrix is a 2D square numpy array
-        if len(contact_matrix.shape) != 2 or contact_matrix.shape[0] != contact_matrix.shape[1]:
+        if (
+            len(contact_matrix.shape) != 2
+            or contact_matrix.shape[0] != contact_matrix.shape[1]
+        ):
             raise ValueError("Contact matrix must be a 2D square numpy array.")
-        
+
         self.contact_matrices[layer_name] = contact_matrix
-        
 
-
-    def add_population(self, Nk: List[float], 
-                       Nk_names: Optional[List[str]] = None) -> None:
+    def add_population(
+        self, Nk: List[float], Nk_names: Optional[List[str]] = None
+    ) -> None:
         """
         Adds population data for different demographic groups.
 
         Args:
             Nk (List[float]): A list representing the population size for each demographic group.
-            Nk_names (Optional[List[str]], optional): A list of demographic group names. If not provided, 
+            Nk_names (Optional[List[str]], optional): A list of demographic group names. If not provided,
                                                       a default list of indices is generated. Defaults to None.
-        
+
         Returns:
             None
         """
@@ -184,50 +192,49 @@ class Population:
             Nk_names = np.array(range(len(Nk)))
         else:
             Nk_names = np.array(Nk_names)
-        
+
         # check that Nk and Nk_names have the same length
         if len(Nk) != len(Nk_names):
             raise ValueError("Nk and Nk_names must have the same length.")
-        
+
         self.Nk_names = Nk_names
         self.Nk = Nk
-        
 
     @property
     def total_population(self) -> float:
         """
         Total population across all demographic groups.
-        
+
         Returns:
             float: Sum of population in all demographic groups
         """
         return float(np.sum(self.Nk))
-    
+
     @property
     def num_groups(self) -> int:
         """
         Number of demographic groups.
-        
+
         Returns:
             int: Number of demographic groups in the population
         """
         return len(self.Nk)
-    
+
     @property
     def layers(self) -> List[str]:
         """
         Available contact matrix layers.
-        
+
         Returns:
             List[str]: Names of available contact layers (e.g., ['home', 'work', 'school'])
         """
         return list(self.contact_matrices.keys())
-    
+
     @property
     def total_contacts(self) -> Dict[str, float]:
         """
         Total number of contacts per layer.
-        
+
         Returns:
             Dict[str, float]: Dictionary mapping layer names to total contacts
         """
@@ -235,12 +242,12 @@ class Population:
             layer: float(np.sum(matrix * self.Nk[:, np.newaxis]))
             for layer, matrix in self.contact_matrices.items()
         }
-    
+
     @property
     def mean_contacts(self) -> Dict[str, float]:
         """
         Mean number of contacts per person per layer.
-        
+
         Returns:
             Dict[str, float]: Dictionary mapping layer names to mean contacts per person
         """
@@ -264,16 +271,16 @@ class Population:
         """
         if len(self.Nk) == 0:
             raise ValueError("No population data has been added")
-            
+
         if len(self.Nk) != len(self.Nk_names):
             raise ValueError(
                 f"Mismatch between population sizes ({len(self.Nk)}) "
                 f"and names ({len(self.Nk_names)})"
             )
-            
+
         if np.any(self.Nk < 0):
             raise ValueError("Population sizes cannot be negative")
-            
+
         if np.any(~np.isfinite(self.Nk)):
             raise ValueError("Population sizes must be finite")
 
@@ -281,20 +288,15 @@ class Population:
         """
         Validate contact matrices for all layers.
         """
-        
-        for layer, matrix in self.contact_matrices.items():
 
+        for layer, matrix in self.contact_matrices.items():
             # Check for negative values
             if np.any(matrix < 0):
-                raise ValueError(
-                    f"Contact matrix '{layer}' contains negative values"
-                )
-                
+                raise ValueError(f"Contact matrix '{layer}' contains negative values")
+
             # Check for non-finite values
             if np.any(~np.isfinite(matrix)):
-                raise ValueError(
-                    f"Contact matrix '{layer}' contains non-finite values"
-                )
+                raise ValueError(f"Contact matrix '{layer}' contains non-finite values")
 
     def _validate_demographic_names(self) -> None:
         """
@@ -304,14 +306,16 @@ class Population:
             raise ValueError("Duplicate demographic group names found")
 
 
-def map_age_groups_to_idx(age_group_mapping: Dict[str, List[str]], 
-                          old_age_groups_idx: Dict[str, int], 
-                          new_age_group_idx: Dict[str, int]) -> Dict[int, int]:
+def map_age_groups_to_idx(
+    age_group_mapping: Dict[str, List[str]],
+    old_age_groups_idx: Dict[str, int],
+    new_age_group_idx: Dict[str, int],
+) -> Dict[int, int]:
     """
     Maps old age groups to new age groups using index mappings.
 
     Args:
-        age_group_mapping (Dict[str, List[str]]): A dictionary where keys are new age groups, 
+        age_group_mapping (Dict[str, List[str]]): A dictionary where keys are new age groups,
                                                   and values are lists of old age groups.
         old_age_groups_idx (Dict[str, int]): A dictionary mapping old age group names to their respective indices.
         new_age_group_idx (Dict[str, int]): A dictionary mapping new age group names to their respective indices.
@@ -319,13 +323,12 @@ def map_age_groups_to_idx(age_group_mapping: Dict[str, List[str]],
     Returns:
         Dict[int, int]: A dictionary mapping old age group indices to new age group indices.
     """
-    
+
     # Initialize the result dictionary
     age_group_mapping_idx = {}
 
     # Iterate through each key-value pair in the first dictionary
     for new_group, old_groups in age_group_mapping.items():
-
         # Get the corresponding integer for this new group
         related_int = new_age_group_idx[new_group]
 
@@ -339,12 +342,14 @@ def map_age_groups_to_idx(age_group_mapping: Dict[str, List[str]],
     return age_group_mapping_idx
 
 
-def aggregate_matrix(initial_matrix: np.ndarray, 
-                     old_population: np.ndarray, 
-                     new_population: np.ndarray, 
-                     age_group_mapping: Dict[str, list], 
-                     old_age_groups_idx: Dict[str, int], 
-                     new_age_group_idx: Dict[str, int]) -> np.ndarray:
+def aggregate_matrix(
+    initial_matrix: np.ndarray,
+    old_population: np.ndarray,
+    new_population: np.ndarray,
+    age_group_mapping: Dict[str, list],
+    old_age_groups_idx: Dict[str, int],
+    new_age_group_idx: Dict[str, int],
+) -> np.ndarray:
     """
     Aggregates a contact matrix based on new demographic groupings.
 
@@ -362,11 +367,13 @@ def aggregate_matrix(initial_matrix: np.ndarray,
 
     # Turn matrix of rates into contacts
     real_contacts = initial_matrix.copy()
-    for i in range(real_contacts.shape[0]): 
+    for i in range(real_contacts.shape[0]):
         real_contacts[i] = real_contacts[i] * old_population[i]
 
     # compute age group mapping
-    age_group_mapping_idxs = map_age_groups_to_idx(age_group_mapping, old_age_groups_idx, new_age_group_idx)
+    age_group_mapping_idxs = map_age_groups_to_idx(
+        age_group_mapping, old_age_groups_idx, new_age_group_idx
+    )
 
     # Determine the number of aggregated groups
     num_aggregated_groups = max(age_group_mapping_idxs.values()) + 1
@@ -382,14 +389,16 @@ def aggregate_matrix(initial_matrix: np.ndarray,
             aggregated_matrix[aggregated_i, aggregated_j] += real_contacts[i, j]
 
     # Turn into rates
-    aggregated_matrix_rate = aggregated_matrix.copy() 
+    aggregated_matrix_rate = aggregated_matrix.copy()
     for i in range(aggregated_matrix_rate.shape[0]):
         aggregated_matrix_rate[i] = aggregated_matrix_rate[i] / new_population[i]
 
     return aggregated_matrix_rate
 
-  
-def aggregate_demographic(data: pd.DataFrame, grouping: Dict[str, List[str]]) -> pd.DataFrame:
+
+def aggregate_demographic(
+    data: pd.DataFrame, grouping: Dict[str, List[str]]
+) -> pd.DataFrame:
     """
     Aggregates demographic data based on a grouping dictionary.
 
@@ -402,18 +411,15 @@ def aggregate_demographic(data: pd.DataFrame, grouping: Dict[str, List[str]]) ->
     """
     Nk_new, Nk_names_new = [], []
 
-    for new_group in grouping.keys(): 
+    for new_group in grouping.keys():
         Nk_names_new.append(new_group)
         sum_value = data.loc[data.group_name.isin(grouping[new_group])]["value"].sum()
         Nk_new.append(sum_value)
 
-    df_Nk_new = pd.DataFrame({
-        "group_name": Nk_names_new,
-        "value": Nk_new
-    })
+    df_Nk_new = pd.DataFrame({"group_name": Nk_names_new, "value": Nk_new})
 
     return df_Nk_new
- 
+
 
 def validate_population_name(population_name: str, path_to_data: str) -> None:
     """
@@ -428,16 +434,20 @@ def validate_population_name(population_name: str, path_to_data: str) -> None:
     """
     # Construct the full path to the locations CSV file
     locations_file = os.path.join(path_to_data, "locations.csv")
-    
+
     # Load the locations data and extract the list of locations
     locations_list = pd.read_csv(locations_file)["location"].values
 
-     # Check if the population name is in the list of locations
+    # Check if the population name is in the list of locations
     if population_name not in locations_list:
-        raise ValueError(f"Location {population_name} not found in the list of supported locations. See {path_to_data}/locations.csv")
-    
+        raise ValueError(
+            f"Location {population_name} not found in the list of supported locations. See {path_to_data}/locations.csv"
+        )
 
-def get_primary_contacts_source(population_name: str, path_to_data: str) -> Optional[str]:
+
+def get_primary_contacts_source(
+    population_name: str, path_to_data: str
+) -> Optional[str]:
     """
     Retrieves the primary contact source for a given population name from the locations data.
 
@@ -446,7 +456,7 @@ def get_primary_contacts_source(population_name: str, path_to_data: str) -> Opti
         path_to_data (str): The path to the directory containing the 'locations.csv' file.
 
     Returns:
-        Optional[str]: The primary contact source for the given population name. 
+        Optional[str]: The primary contact source for the given population name.
                        Returns None if the population name is not found.
 
     Raises:
@@ -454,25 +464,29 @@ def get_primary_contacts_source(population_name: str, path_to_data: str) -> Opti
     """
     # Construct the full path to the locations CSV file
     locations_file = os.path.join(path_to_data, "locations.csv")
-    
+
     # Load the contact matrices sources data
     contact_matrices_sources = pd.read_csv(locations_file)
-    
+
     # Filter the data for the specified population name
     source_location = contact_matrices_sources.loc[
-        contact_matrices_sources['location'] == population_name,
-        'primary_contact_source'
+        contact_matrices_sources["location"] == population_name,
+        "primary_contact_source",
     ]
-    
+
     # Check if the population name was found
     if source_location.empty:
-        raise ValueError(f"Population name '{population_name}' not found in {locations_file}.")
-    
+        raise ValueError(
+            f"Population name '{population_name}' not found in {locations_file}."
+        )
+
     # Retrieve and return the primary contact source
     return source_location.iloc[0]
 
 
-def validate_contacts_source(contacts_source: str, supported_contacts_sources: List[str]) -> None:
+def validate_contacts_source(
+    contacts_source: str, supported_contacts_sources: List[str]
+) -> None:
     """
     Validates if a given contacts source is in the list of supported contact sources.
 
@@ -484,10 +498,14 @@ def validate_contacts_source(contacts_source: str, supported_contacts_sources: L
         ValueError: If the contacts_source is not found in the list of supported sources.
     """
     if contacts_source not in supported_contacts_sources:
-        raise ValueError(f"Source {contacts_source} not found in the list of supported sources. Supported sources are {supported_contacts_sources}")
+        raise ValueError(
+            f"Source {contacts_source} not found in the list of supported sources. Supported sources are {supported_contacts_sources}"
+        )
 
 
-def validate_age_group_mapping(age_group_mapping: Dict[str, List[str]], allowed_values: List[str]) -> None:
+def validate_age_group_mapping(
+    age_group_mapping: Dict[str, List[str]], allowed_values: List[str]
+) -> None:
     """
     Validates that all age group mapping values are within the allowed values.
 
@@ -498,20 +516,20 @@ def validate_age_group_mapping(age_group_mapping: Dict[str, List[str]], allowed_
     Raises:
         ValueError: If any value in the age group mapping is not in the list of allowed values.
     """
-    values = np.concatenate(list(age_group_mapping.values())) 
-    if not np.all(np.isin(values, allowed_values)): 
+    values = np.concatenate(list(age_group_mapping.values()))
+    if not np.all(np.isin(values, allowed_values)):
         raise ValueError(f"Age group mapping values must be in {allowed_values}")
 
 
 def load_epydemix_population(
-            population_name: str,
-            contacts_source: Optional[str] = None,
-            path_to_data: Optional[str] = None,
-            layers: List[str] = ["school", "work", "home", "community"],
-            age_group_mapping: Optional[Dict[str, List[str]]] = None,
-            supported_contacts_sources: List[str] = ["prem_2017", "prem_2021", "mistry_2021"],
-            path_to_data_github: str = "https://raw.githubusercontent.com/epistorm/epydemix-data/main/") -> 'Population':
-    
+    population_name: str,
+    contacts_source: Optional[str] = None,
+    path_to_data: Optional[str] = None,
+    layers: List[str] = ["school", "work", "home", "community"],
+    age_group_mapping: Optional[Dict[str, List[str]]] = None,
+    supported_contacts_sources: List[str] = ["prem_2017", "prem_2021", "mistry_2021"],
+    path_to_data_github: str = "https://raw.githubusercontent.com/epistorm/epydemix-data/main/",
+) -> "Population":
     """
     Loads population and contact matrix data for a specified population.
 
@@ -529,8 +547,8 @@ def load_epydemix_population(
 
     Raises:
         ValueError: If any provided value is not valid or if there are issues with the data files.
-    """ 
-        
+    """
+
     population = Population(name=population_name)
 
     # If path_to_data is None, use the GitHub URL
@@ -543,7 +561,7 @@ def load_epydemix_population(
     validate_population_name(population_name, path_to_data)
 
     # Check if contacts_source is supported
-    if contacts_source is None: 
+    if contacts_source is None:
         contacts_source = get_primary_contacts_source(population_name, path_to_data)
     validate_contacts_source(contacts_source, supported_contacts_sources)
 
@@ -553,43 +571,70 @@ def load_epydemix_population(
     if is_remote:
         df = pd.read_csv(path_to_data + demographic_file)  # Fetch from URL
     else:
-        demographic_path = Path(path_to_data) / "data" / population_name / "demographic" / "age_distribution.csv"
+        demographic_path = (
+            Path(path_to_data)
+            / "data"
+            / population_name
+            / "demographic"
+            / "age_distribution.csv"
+        )
         df = pd.read_csv(demographic_path)
 
     Nk = df  # Assign the loaded DataFrame
 
     # Handle contact matrices aggregation
-    if contacts_source in ["prem_2017", "prem_2021"]: 
+    if contacts_source in ["prem_2017", "prem_2021"]:
         Nk = aggregate_demographic(Nk, demographic_grouping_prem)
 
     # Determine age group mapping
-    if age_group_mapping is None: 
-        age_group_mapping = contacts_age_group_mapping_prem if contacts_source in ["prem_2017", "prem_2021"] else contacts_age_group_mapping_mistry
+    if age_group_mapping is None:
+        age_group_mapping = (
+            contacts_age_group_mapping_prem
+            if contacts_source in ["prem_2017", "prem_2021"]
+            else contacts_age_group_mapping_mistry
+        )
 
     validate_age_group_mapping(age_group_mapping, Nk.group_name.values)
 
     # Aggregate population data
     Nk_new = aggregate_demographic(Nk, age_group_mapping)
-    population.add_population(Nk=Nk_new["value"].values, Nk_names=Nk_new["group_name"].values)
+    population.add_population(
+        Nk=Nk_new["value"].values, Nk_names=Nk_new["group_name"].values
+    )
 
     # Load contact matrices
     for layer_name in layers:
         contact_matrix_file = f"data/{population_name}/contact_matrices/{contacts_source}/contacts_matrix_{layer_name}.csv"
 
         if is_remote:
-            C = pd.read_csv(path_to_data + contact_matrix_file, header=None).values  # Load from URL
+            C = pd.read_csv(
+                path_to_data + contact_matrix_file, header=None
+            ).values  # Load from URL
         else:
-            contact_matrix_path = Path(path_to_data) / "data" / population_name / "contact_matrices" / contacts_source / f"contacts_matrix_{layer_name}.csv"
-            C = pd.read_csv(contact_matrix_path, header=None).values  # Load from local file
+            contact_matrix_path = (
+                Path(path_to_data)
+                / "data"
+                / population_name
+                / "contact_matrices"
+                / contacts_source
+                / f"contacts_matrix_{layer_name}.csv"
+            )
+            C = pd.read_csv(
+                contact_matrix_path, header=None
+            ).values  # Load from local file
 
         # Aggregate contact matrices
         C_aggr = aggregate_matrix(
-            C, 
-            old_population=Nk["value"].values, 
-            new_population=Nk_new["value"].values, 
-            age_group_mapping=age_group_mapping, 
-            old_age_groups_idx={name: idx for idx, name in enumerate(Nk.group_name.values)}, 
-            new_age_group_idx={name: idx for idx, name in enumerate(age_group_mapping.keys())}
+            C,
+            old_population=Nk["value"].values,
+            new_population=Nk_new["value"].values,
+            age_group_mapping=age_group_mapping,
+            old_age_groups_idx={
+                name: idx for idx, name in enumerate(Nk.group_name.values)
+            },
+            new_age_group_idx={
+                name: idx for idx, name in enumerate(age_group_mapping.keys())
+            },
         )
 
         population.add_contact_matrix(C_aggr, layer_name=layer_name)
@@ -597,8 +642,10 @@ def load_epydemix_population(
     return population
 
 
-def get_available_locations(path_to_data: Optional[str] = None,
-                            path_to_data_github: str = "https://raw.githubusercontent.com/epistorm/epydemix-data/main/") -> pd.DataFrame: 
+def get_available_locations(
+    path_to_data: Optional[str] = None,
+    path_to_data_github: str = "https://raw.githubusercontent.com/epistorm/epydemix-data/main/",
+) -> pd.DataFrame:
     """
     Returns a list of available locations.
 
@@ -619,5 +666,5 @@ def get_available_locations(path_to_data: Optional[str] = None,
     if is_remote:
         locations_file = path_to_data + "locations.csv"
     else:
-        locations_file = Path(path_to_data) / "locations.csv"    
+        locations_file = Path(path_to_data) / "locations.csv"
     return pd.read_csv(locations_file)

--- a/epydemix/utils/__init__.py
+++ b/epydemix/utils/__init__.py
@@ -1,17 +1,31 @@
 # epydemix/utils/__init__.py
 
-from .utils import compute_days, compute_simulation_dates, convert_to_2Darray, combine_simulation_outputs, get_initial_conditions_dict
-from .abc_smc_utils import sample_prior, compute_effective_sample_size, weighted_quantile, Perturbation, DefaultPerturbationDiscrete, DefaultPerturbationContinuous
+from .abc_smc_utils import (
+    DefaultPerturbationContinuous,
+    DefaultPerturbationDiscrete,
+    Perturbation,
+    compute_effective_sample_size,
+    sample_prior,
+    weighted_quantile,
+)
+from .utils import (
+    combine_simulation_outputs,
+    compute_days,
+    compute_simulation_dates,
+    convert_to_2Darray,
+    get_initial_conditions_dict,
+)
+
 __all__ = [
-    'compute_days',
-    'compute_simulation_dates',
-    'convert_to_2Darray',
-    'sample_prior',
-    'compute_effective_sample_size',
-    'weighted_quantile',
-    'Perturbation',
-    'DefaultPerturbationDiscrete',
-    'DefaultPerturbationContinuous',
-    'combine_simulation_outputs',
-    'get_initial_conditions_dict'
+    "compute_days",
+    "compute_simulation_dates",
+    "convert_to_2Darray",
+    "sample_prior",
+    "compute_effective_sample_size",
+    "weighted_quantile",
+    "Perturbation",
+    "DefaultPerturbationDiscrete",
+    "DefaultPerturbationContinuous",
+    "combine_simulation_outputs",
+    "get_initial_conditions_dict",
 ]

--- a/epydemix/utils/abc_smc_utils.py
+++ b/epydemix/utils/abc_smc_utils.py
@@ -1,7 +1,7 @@
-import numpy as np 
-from scipy.stats import norm
-from typing import Dict, List, Tuple, Optional, Union, Any
 from abc import ABC, abstractmethod
+from typing import Union
+
+import numpy as np
 
 
 def fast_normal_pdf(x, mean, std):
@@ -35,9 +35,10 @@ class DefaultPerturbationContinuous(Perturbation):
     """
     Componenent-wise normal perturbation kernel with adaptive standard deviation (Beaumont et al. (2009)).
     """
+
     def __init__(self, param_name):
         super().__init__(param_name)
-        self.std = 0.1  
+        self.std = 0.1
 
     def propose(self, x):
         """Propose a new value based on the current value."""
@@ -58,8 +59,8 @@ class DefaultPerturbationContinuous(Perturbation):
 class DefaultPerturbationDiscrete(Perturbation):
     def __init__(self, param_name, prior, jump_probability=0.3):
         super().__init__(param_name)
-        self.prior = prior  
-        self.support = np.arange(self.prior.support()[0], self.prior.support()[1]+1)
+        self.prior = prior
+        self.support = np.arange(self.prior.support()[0], self.prior.support()[1] + 1)
         self.jump_probability = jump_probability
         self.rest_prob = jump_probability / (len(self.support) - 1)
 
@@ -70,7 +71,7 @@ class DefaultPerturbationDiscrete(Perturbation):
             while proposed == x:
                 proposed = np.random.choice(self.support)
             return proposed
-        return x 
+        return x
 
     def pdf(self, x, center):
         """Transition probability for the discrete parameter."""
@@ -82,7 +83,7 @@ class DefaultPerturbationDiscrete(Perturbation):
 
     def update(self, particles, weights, param_names):
         """Update jump_probability or other characteristics if needed."""
-        pass 
+        pass
 
 
 def sample_prior(priors, param_names):
@@ -109,10 +110,8 @@ def compute_effective_sample_size(weights: np.ndarray) -> float:
 
 
 def weighted_quantile(
-        values: Union[np.ndarray, list],
-        weights: Union[np.ndarray, list],
-        quantile: float
-    ) -> float:
+    values: Union[np.ndarray, list], weights: Union[np.ndarray, list], quantile: float
+) -> float:
     """
     Compute the weighted quantile of a dataset.
 
@@ -130,10 +129,10 @@ def weighted_quantile(
     # Ensure quantile is between 0 and 1
     if not (0 <= quantile <= 1):
         raise ValueError("Quantile must be between 0 and 1.")
-    
+
     values = np.asarray(values)
     weights = np.asarray(weights)
-    
+
     # Ensure that weights sum to 1
     weights /= np.sum(weights)
 

--- a/epydemix/visualization/__init__.py
+++ b/epydemix/visualization/__init__.py
@@ -1,14 +1,23 @@
 # epydemix/visualization/__init__.py
 
-from .plotting import plot_quantiles, plot_posterior_distribution, plot_posterior_distribution_2d, plot_contact_matrix, plot_population, plot_spectral_radius, plot_distance_distribution, plot_trajectories
+from .plotting import (
+    plot_contact_matrix,
+    plot_distance_distribution,
+    plot_population,
+    plot_posterior_distribution,
+    plot_posterior_distribution_2d,
+    plot_quantiles,
+    plot_spectral_radius,
+    plot_trajectories,
+)
 
 __all__ = [
-    'plot_quantiles',
-    'plot_posterior_distribution',
-    'plot_posterior_distribution_2d',
-    'plot_contact_matrix',
-    'plot_population',
-    'plot_spectral_radius',
-    'plot_distance_distribution',
-    'plot_trajectories'
+    "plot_quantiles",
+    "plot_posterior_distribution",
+    "plot_posterior_distribution_2d",
+    "plot_contact_matrix",
+    "plot_population",
+    "plot_spectral_radius",
+    "plot_distance_distribution",
+    "plot_trajectories",
 ]

--- a/epydemix/visualization/plotting.py
+++ b/epydemix/visualization/plotting.py
@@ -1,23 +1,24 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 import pandas as pd
-from typing import List, Optional, Union, Any, Tuple, Dict
-import matplotlib.dates as mdates
+import seaborn as sns
 
 
 def get_black_to_grey(n):
     """Generate `n` grayscale colors starting with pure black."""
     if n < 1:
         raise ValueError("n must be at least 1")
-    greys = np.linspace(0, 255, n, dtype=int)  
-    greys[0] = 0 
+    greys = np.linspace(0, 255, n, dtype=int)
+    greys[0] = 0
     return [(g, g, g) for g in greys]
 
 
-def get_timeseries_data(df_quantiles: pd.DataFrame, 
-                        column: str, 
-                        quantile: float) -> pd.DataFrame:
+def get_timeseries_data(
+    df_quantiles: pd.DataFrame, column: str, quantile: float
+) -> pd.DataFrame:
     """
     Extracts the time series data for a specific column (compartment or demographic group) and quantile.
 
@@ -32,26 +33,28 @@ def get_timeseries_data(df_quantiles: pd.DataFrame,
     return df_quantiles.loc[(df_quantiles["quantile"] == quantile)][["date", column]]
 
 
-def plot_quantiles(df_quantiles: pd.DataFrame,
-                  columns: Union[List[str], str], 
-                  data: Optional[pd.DataFrame] = None,
-                  data_date_column: str = "date",
-                  ax: Optional[plt.Axes] = None,
-                  lower_q: float = 0.05, 
-                  upper_q: float = 0.95, 
-                  show_median: bool = True,
-                  show_data: bool = False,
-                  ci_alpha: float = 0.3, 
-                  title: str = "", 
-                  ylabel: str = "",  
-                  xlabel: str = "",  
-                  show_legend: bool = True, 
-                  legend_loc: str = "upper left",  
-                  palette: str = "Dark2", 
-                  colors: Optional[Union[List[str], str]] = None,
-                  labels: Optional[Union[List[str], str]] = None,
-                  y_scale: str = "linear",  
-                  show_grid: bool = True) -> plt.Axes:
+def plot_quantiles(
+    df_quantiles: pd.DataFrame,
+    columns: Union[List[str], str],
+    data: Optional[pd.DataFrame] = None,
+    data_date_column: str = "date",
+    ax: Optional[plt.Axes] = None,
+    lower_q: float = 0.05,
+    upper_q: float = 0.95,
+    show_median: bool = True,
+    show_data: bool = False,
+    ci_alpha: float = 0.3,
+    title: str = "",
+    ylabel: str = "",
+    xlabel: str = "",
+    show_legend: bool = True,
+    legend_loc: str = "upper left",
+    palette: str = "Dark2",
+    colors: Optional[Union[List[str], str]] = None,
+    labels: Optional[Union[List[str], str]] = None,
+    y_scale: str = "linear",
+    show_grid: bool = True,
+) -> plt.Axes:
     """
     Plots quantiles for compartments over time with optional observed data.
 
@@ -84,7 +87,7 @@ def plot_quantiles(df_quantiles: pd.DataFrame,
         columns = [columns]
 
     if ax is None:
-        _, ax = plt.subplots(dpi=300, figsize=(10,4))
+        _, ax = plt.subplots(dpi=300, figsize=(10, 4))
 
     if colors is None:
         colors = sns.color_palette(palette, len(columns))
@@ -100,17 +103,27 @@ def plot_quantiles(df_quantiles: pd.DataFrame,
     for t, (column, color, label) in enumerate(zip(columns, colors, labels)):
         if show_median:
             df_med = get_timeseries_data(df_quantiles, column, 0.5)
-            p1, = ax.plot(df_med.date, df_med[column].values, 
-                         color=color, label=label, zorder=2)
+            (p1,) = ax.plot(
+                df_med.date, df_med[column].values, color=color, label=label, zorder=2
+            )
 
         df_q1 = get_timeseries_data(df_quantiles, column, lower_q)
         df_q2 = get_timeseries_data(df_quantiles, column, upper_q)
-        p2 = ax.fill_between(df_q1.date, df_q1[column].values, df_q2[column].values, 
-                            alpha=ci_alpha, color=color, linewidth=0., zorder=1)
-        
+        p2 = ax.fill_between(
+            df_q1.date,
+            df_q1[column].values,
+            df_q2[column].values,
+            alpha=ci_alpha,
+            color=color,
+            linewidth=0.0,
+            zorder=1,
+        )
+
         if show_median:
             pleg.append((p1, p2))
-            handles.append(f"{label} (median, {np.round((1 - lower_q * 2) * 100, 0)}% CI)")
+            handles.append(
+                f"{label} (median, {np.round((1 - lower_q * 2) * 100, 0)}% CI)"
+            )
         else:
             pleg.append(p2)
             handles.append(f"{label} ({np.round((1 - lower_q * 2) * 100, 0)}% CI)")
@@ -118,7 +131,14 @@ def plot_quantiles(df_quantiles: pd.DataFrame,
     if show_data and data is not None:
         data_colors = get_black_to_grey(len(columns))
         for column, data_color, label in zip(columns, data_colors, labels):
-            p_actual = ax.scatter(data[data_date_column], data[column], s=10, color=data_color, zorder=3, label=f"observed ({label})")
+            p_actual = ax.scatter(
+                data[data_date_column],
+                data[column],
+                s=10,
+                color=data_color,
+                zorder=3,
+                label=f"observed ({label})",
+            )
             if show_legend:
                 pleg.append(p_actual)
                 handles.append(f"observed ({label})")
@@ -126,45 +146,47 @@ def plot_quantiles(df_quantiles: pd.DataFrame,
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", linewidth=0.3, alpha=0.5, zorder=0)
-    
+
     # Labels and formatting
     ax.set_title(title)
     ax.set_ylabel(ylabel)
     ax.set_xlabel(xlabel)
     ax.set_yscale(y_scale)
-    
+
     if show_legend and pleg:
         ax.legend(pleg, handles, loc=legend_loc, frameon=False)
-    
+
     plt.tight_layout()
-    
+
     return ax
 
 
-def plot_posterior_distribution(posterior: pd.DataFrame,
-                              parameter: str,
-                              ax: Optional[plt.Axes] = None,
-                              xlabel: Optional[str] = None,
-                              ylabel: Optional[str] = None,
-                              kind: str = "hist",
-                              color: str = "dodgerblue",
-                              xlim: Optional[Tuple[float, float]] = None,
-                              prior: Optional[Any] = None,
-                              prior_range: bool = False,
-                              title: Optional[str] = None,
-                              fontsize: int = 10,
-                              show_grid: bool = True,
-                              show_kde: bool = True,
-                              show_rug: bool = False,
-                              figsize: Tuple[int, int] = (10, 4),
-                              stat: str = "density",
-                              bins: Union[int, str] = "auto",
-                              alpha: float = 0.4,
-                              vertical_lines: Optional[Dict[str, Dict[str, Any]]] = None,
-                              **kwargs) -> plt.Axes:
+def plot_posterior_distribution(
+    posterior: pd.DataFrame,
+    parameter: str,
+    ax: Optional[plt.Axes] = None,
+    xlabel: Optional[str] = None,
+    ylabel: Optional[str] = None,
+    kind: str = "hist",
+    color: str = "dodgerblue",
+    xlim: Optional[Tuple[float, float]] = None,
+    prior: Optional[Any] = None,
+    prior_range: bool = False,
+    title: Optional[str] = None,
+    fontsize: int = 10,
+    show_grid: bool = True,
+    show_kde: bool = True,
+    show_rug: bool = False,
+    figsize: Tuple[int, int] = (10, 4),
+    stat: str = "density",
+    bins: Union[int, str] = "auto",
+    alpha: float = 0.4,
+    vertical_lines: Optional[Dict[str, Dict[str, Any]]] = None,
+    **kwargs,
+) -> plt.Axes:
     """
     Plots the distribution of a parameter.
 
@@ -211,57 +233,57 @@ def plot_posterior_distribution(posterior: pd.DataFrame,
 
     # Set default labels
     xlabel = xlabel or parameter
-    
+
     if kind == "hist":
-        sns.histplot(data=posterior,
-                    x=parameter,
-                    ax=ax,
-                    color=color,
-                    stat=stat,
-                    bins=bins,
-                    alpha=alpha,
-                    kde=show_kde,
-                    **kwargs)
+        sns.histplot(
+            data=posterior,
+            x=parameter,
+            ax=ax,
+            color=color,
+            stat=stat,
+            bins=bins,
+            alpha=alpha,
+            kde=show_kde,
+            **kwargs,
+        )
     elif kind == "kde":
-        sns.kdeplot(data=posterior,
-                   x=parameter,
-                   ax=ax,
-                   color=color,
-                   fill=True,
-                   alpha=alpha,
-                   **kwargs)
+        sns.kdeplot(
+            data=posterior,
+            x=parameter,
+            ax=ax,
+            color=color,
+            fill=True,
+            alpha=alpha,
+            **kwargs,
+        )
     elif kind == "ecdf":
-        sns.ecdfplot(data=posterior,
-                    x=parameter,
-                    ax=ax,
-                    color=color,
-                    **kwargs)
+        sns.ecdfplot(data=posterior, x=parameter, ax=ax, color=color, **kwargs)
     else:
-        raise ValueError(f"Unknown kind for plot: {kind}. Must be 'hist', 'kde', or 'ecdf'")
+        raise ValueError(
+            f"Unknown kind for plot: {kind}. Must be 'hist', 'kde', or 'ecdf'"
+        )
 
     # Add rug plot if requested
     if show_rug:
-        sns.rugplot(data=posterior,
-                   x=parameter,
-                   ax=ax,
-                   color=color,
-                   alpha=alpha/2)
+        sns.rugplot(data=posterior, x=parameter, ax=ax, color=color, alpha=alpha / 2)
 
     # Add vertical lines if specified
     if vertical_lines:
         for line_specs in vertical_lines.values():
-            ax.axvline(x=line_specs['x'],
-                      color=line_specs.get('color', 'red'),
-                      linestyle=line_specs.get('linestyle', '--'),
-                      label=line_specs.get('label', None),
-                      alpha=line_specs.get('alpha', 1.0))
-            if line_specs.get('label'):
+            ax.axvline(
+                x=line_specs["x"],
+                color=line_specs.get("color", "red"),
+                linestyle=line_specs.get("linestyle", "--"),
+                label=line_specs.get("label", None),
+                alpha=line_specs.get("alpha", 1.0),
+            )
+            if line_specs.get("label"):
                 ax.legend(frameon=False)
 
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", linewidth=0.3, alpha=0.5)
 
@@ -281,7 +303,7 @@ def plot_posterior_distribution(posterior: pd.DataFrame,
         ax.set_title(title, fontsize=fontsize + 2, pad=20)
 
     # Tick formatting
-    ax.tick_params(axis='both', which='major', labelsize=fontsize-2)
+    ax.tick_params(axis="both", which="major", labelsize=fontsize - 2)
 
     # Adjust layout
     plt.tight_layout()
@@ -289,30 +311,32 @@ def plot_posterior_distribution(posterior: pd.DataFrame,
     return ax
 
 
-def plot_posterior_distribution_2d(posterior: pd.DataFrame,
-                                 parameter_x: str, 
-                                 parameter_y: str, 
-                                 ax: Optional[plt.Axes] = None, 
-                                 xlabel: Optional[str] = None, 
-                                 ylabel: Optional[str] = None, 
-                                 kind: str = "hist", 
-                                 palette: str = "Blues", 
-                                 xlim: Optional[Tuple[float, float]] = None,
-                                 ylim: Optional[Tuple[float, float]] = None,
-                                 prior_x: Optional[Any] = None,
-                                 prior_y: Optional[Any] = None,
-                                 prior_range: bool = False,
-                                 title: Optional[str] = None,
-                                 fontsize: int = 10,
-                                 cmap: Optional[str] = None,
-                                 show_grid: bool = True,
-                                 levels: int = 10,
-                                 figsize: Tuple[int, int] = (6, 6),
-                                 scatter: bool = False,
-                                 scatter_alpha: float = 0.5,
-                                 scatter_size: int = 20,
-                                 scatter_color: str = "k",
-                                 **kwargs) -> plt.Axes:
+def plot_posterior_distribution_2d(
+    posterior: pd.DataFrame,
+    parameter_x: str,
+    parameter_y: str,
+    ax: Optional[plt.Axes] = None,
+    xlabel: Optional[str] = None,
+    ylabel: Optional[str] = None,
+    kind: str = "hist",
+    palette: str = "Blues",
+    xlim: Optional[Tuple[float, float]] = None,
+    ylim: Optional[Tuple[float, float]] = None,
+    prior_x: Optional[Any] = None,
+    prior_y: Optional[Any] = None,
+    prior_range: bool = False,
+    title: Optional[str] = None,
+    fontsize: int = 10,
+    cmap: Optional[str] = None,
+    show_grid: bool = True,
+    levels: int = 10,
+    figsize: Tuple[int, int] = (6, 6),
+    scatter: bool = False,
+    scatter_alpha: float = 0.5,
+    scatter_size: int = 20,
+    scatter_color: str = "k",
+    **kwargs,
+) -> plt.Axes:
     """
     Plots the 2D joint distribution of two parameters.
 
@@ -351,64 +375,71 @@ def plot_posterior_distribution_2d(posterior: pd.DataFrame,
     """
     if ax is None:
         _, ax = plt.subplots(figsize=figsize, dpi=300)
-    
+
     # Set default labels if not provided
     xlabel = xlabel or parameter_x
     ylabel = ylabel or parameter_y
-    
+
     # Set default colormap
     if cmap is None:
         cmap = palette if kind == "hist" else sns.color_palette(palette, as_cmap=True)
 
     # Plot based on kind
     if kind == "hist":
-        sns.histplot(data=posterior, 
-                          x=parameter_x, 
-                          y=parameter_y, 
-                          ax=ax,
-                          cmap=cmap,
-                          **kwargs)
-            
+        sns.histplot(
+            data=posterior, x=parameter_x, y=parameter_y, ax=ax, cmap=cmap, **kwargs
+        )
+
     elif kind == "kde":
-        sns.kdeplot(data=posterior,
-                    x=parameter_x,
-                    y=parameter_y,
-                    ax=ax,
-                    cmap=cmap,
-                    levels=levels,
-                    fill=True,
-                    **kwargs)
-            
+        sns.kdeplot(
+            data=posterior,
+            x=parameter_x,
+            y=parameter_y,
+            ax=ax,
+            cmap=cmap,
+            levels=levels,
+            fill=True,
+            **kwargs,
+        )
+
     elif kind == "scatter":
-        ax.scatter(posterior[parameter_x],
-                  posterior[parameter_y],
-                  alpha=scatter_alpha,
-                  s=scatter_size,
-                  c=scatter_color,
-                  **kwargs)
+        ax.scatter(
+            posterior[parameter_x],
+            posterior[parameter_y],
+            alpha=scatter_alpha,
+            s=scatter_size,
+            c=scatter_color,
+            **kwargs,
+        )
     else:
-        raise ValueError(f"Unknown plot kind: {kind}. Must be 'hist', 'kde', or 'scatter'")
+        raise ValueError(
+            f"Unknown plot kind: {kind}. Must be 'hist', 'kde', or 'scatter'"
+        )
 
     # Add scatter points if requested (for hist/kde)
     if scatter and kind != "scatter":
-        ax.scatter(posterior[parameter_x],
-                  posterior[parameter_y],
-                  alpha=scatter_alpha,
-                  s=scatter_size,
-                  c=scatter_color,
-                  zorder=2)
+        ax.scatter(
+            posterior[parameter_x],
+            posterior[parameter_y],
+            alpha=scatter_alpha,
+            s=scatter_size,
+            c=scatter_color,
+            zorder=2,
+        )
 
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(linestyle="--", linewidth=0.3, alpha=0.5)
 
     # Set axis limits based on prior ranges or explicit limits
     if prior_range:
         if prior_x is None or prior_y is None:
-            raise ValueError("Both prior_x and prior_y must be provided when prior_range is True")
+            raise ValueError(
+                "Both prior_x and prior_y must be provided when prior_range is True"
+            )
         ax.set_xlim(prior_x.ppf(0), prior_x.ppf(1))
         ax.set_ylim(prior_y.ppf(0), prior_y.ppf(1))
     else:
@@ -425,7 +456,7 @@ def plot_posterior_distribution_2d(posterior: pd.DataFrame,
     ax.set_title(title, fontsize=fontsize + 2, pad=20)
 
     # Tick formatting
-    ax.tick_params(axis='both', which='major', labelsize=fontsize-2)
+    ax.tick_params(axis="both", which="major", labelsize=fontsize - 2)
 
     # Adjust layout
     plt.tight_layout()
@@ -433,33 +464,45 @@ def plot_posterior_distribution_2d(posterior: pd.DataFrame,
     return ax
 
 
-def plot_selected_trajectories(calibration_results, ax=None, show_data=True, columns="data", 
-                               lower_q=0.05, upper_q=0.95, show_median=True, 
-                               ci_alpha=0.3, title="", show_legend=True, ylabel="", 
-                               palette="Dark2"):
+def plot_selected_trajectories(
+    calibration_results,
+    ax=None,
+    show_data=True,
+    columns="data",
+    lower_q=0.05,
+    upper_q=0.95,
+    show_median=True,
+    ci_alpha=0.3,
+    title="",
+    show_legend=True,
+    ylabel="",
+    palette="Dark2",
+):
     """
     TODO
     """
     return 0
 
 
-def plot_contact_matrix(population: Any,
-                       layer: str,
-                       ax: Optional[plt.Axes] = None,
-                       cmap: str = "YlOrRd",
-                       show_values: bool = False,
-                       title: Optional[str] = None,
-                       show_colorbar: bool = True,
-                       fmt: str = ".1f",
-                       fontsize: int = 8,
-                       rotation: int = 45,
-                       figsize: Tuple[int, int] = (10, 8),
-                       vmin: Optional[float] = None,
-                       vmax: Optional[float] = None,
-                       origin: str = "lower") -> plt.Axes:
+def plot_contact_matrix(
+    population: Any,
+    layer: str,
+    ax: Optional[plt.Axes] = None,
+    cmap: str = "YlOrRd",
+    show_values: bool = False,
+    title: Optional[str] = None,
+    show_colorbar: bool = True,
+    fmt: str = ".1f",
+    fontsize: int = 8,
+    rotation: int = 45,
+    figsize: Tuple[int, int] = (10, 8),
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+    origin: str = "lower",
+) -> plt.Axes:
     """
     Plot a contact matrix heatmap.
-    
+
     Args:
         population: Population object containing contact matrices
         layer: Name of the contact layer to plot
@@ -475,37 +518,36 @@ def plot_contact_matrix(population: Any,
         vmin: Minimum value for colormap scaling
         vmax: Maximum value for colormap scaling
         origin: Whether to plot the matrix with the origin at the bottom left (default) or top left
-        
+
     Returns:
         plt.Axes: The matplotlib axes object
-        
+
     Raises:
         KeyError: If specified layer doesn't exist
     """
     if layer not in population.contact_matrices:
-        raise KeyError(f"Layer '{layer}' not found. Available layers: {population.layers}")
-    
+        raise KeyError(
+            f"Layer '{layer}' not found. Available layers: {population.layers}"
+        )
+
     # Get contact matrix
     matrix = population.contact_matrices[layer]
-    
+
     # Create figure if needed
     if ax is None:
         _, ax = plt.subplots(figsize=figsize)
-    
+
     # Create heatmap
-    im = ax.imshow(matrix, 
-                   cmap=cmap, 
-                   aspect='equal',
-                   vmin=vmin,
-                   vmax=vmax, 
-                   origin=origin)
-    
+    im = ax.imshow(
+        matrix, cmap=cmap, aspect="equal", vmin=vmin, vmax=vmax, origin=origin
+    )
+
     # Show colorbar
     if show_colorbar:
         cbar = plt.colorbar(im, ax=ax)
-        cbar.set_label('Contacts per day', fontsize=fontsize)
+        cbar.set_label("Contacts per day", fontsize=fontsize)
         cbar.ax.tick_params(labelsize=fontsize)
-    
+
     # Show values in cells
     if show_values:
         for i in range(matrix.shape[0]):
@@ -513,56 +555,63 @@ def plot_contact_matrix(population: Any,
                 value = matrix[i, j]
                 text = format(value, fmt)
                 # Determine text color based on background
-                text_color = 'white' if value > (vmax or matrix.max())/2 else 'black'
-                ax.text(j, i, text,
-                       ha="center", va="center",
-                       color=text_color,
-                       fontsize=fontsize)
-    
+                text_color = "white" if value > (vmax or matrix.max()) / 2 else "black"
+                ax.text(
+                    j,
+                    i,
+                    text,
+                    ha="center",
+                    va="center",
+                    color=text_color,
+                    fontsize=fontsize,
+                )
+
     # Set labels and ticks
     ax.set_xticks(np.arange(len(population.Nk_names)))
     ax.set_yticks(np.arange(len(population.Nk_names)))
-    ax.set_xticklabels(population.Nk_names, rotation=rotation, ha='center')
+    ax.set_xticklabels(population.Nk_names, rotation=rotation, ha="center")
     ax.set_yticklabels(population.Nk_names)
-    
+
     # Adjust tick label sizes
-    ax.tick_params(axis='both', which='major', labelsize=fontsize)
-    
+    ax.tick_params(axis="both", which="major", labelsize=fontsize)
+
     # Set title
     if title is None:
         title = f"Contact Matrix - {layer}"
     ax.set_title(title, fontsize=fontsize + 2)
-    
+
     # Add labels
     ax.set_xlabel("Age group (contacted)", fontsize=fontsize)
     ax.set_ylabel("Age group (contacting)", fontsize=fontsize)
-    
+
     # Add grid to better separate cells
-    ax.set_xticks(np.arange(-.5, len(population.Nk_names), 1), minor=True)
-    ax.set_yticks(np.arange(-.5, len(population.Nk_names), 1), minor=True)
-    ax.grid(which='minor', color='w', linestyle='-', linewidth=0.5)
-    
+    ax.set_xticks(np.arange(-0.5, len(population.Nk_names), 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, len(population.Nk_names), 1), minor=True)
+    ax.grid(which="minor", color="w", linestyle="-", linewidth=0.5)
+
     # Adjust layout
     plt.tight_layout()
-    
+
     return ax
 
 
-def plot_population(population: Any, 
-                   ax: Optional[plt.Axes] = None,
-                   title: Optional[str] = None,
-                   color: str = "dodgerblue",
-                   show_perc: bool = False,
-                   fontsize: int = 10,
-                   rotation: int = 45,
-                   figsize: Tuple[int, int] = (10, 6),
-                   bar_width: float = 0.8,
-                   show_grid: bool = True,
-                   ylabel: Optional[str] = None,
-                   xlabel: str = "Age group",
-                   show_values: bool = True,
-                   fmt: str = ".1f",
-                   value_fontsize: Optional[int] = None) -> plt.Axes:
+def plot_population(
+    population: Any,
+    ax: Optional[plt.Axes] = None,
+    title: Optional[str] = None,
+    color: str = "dodgerblue",
+    show_perc: bool = False,
+    fontsize: int = 10,
+    rotation: int = 45,
+    figsize: Tuple[int, int] = (10, 6),
+    bar_width: float = 0.8,
+    show_grid: bool = True,
+    ylabel: Optional[str] = None,
+    xlabel: str = "Age group",
+    show_values: bool = True,
+    fmt: str = ".1f",
+    value_fontsize: Optional[int] = None,
+) -> plt.Axes:
     """
     Plot the population distribution across demographic groups.
 
@@ -595,70 +644,75 @@ def plot_population(population: Any,
         values = 100 * values / np.sum(values)
 
     # Create bars
-    bars = ax.bar(population.Nk_names, values, 
-                 color=color, width=bar_width)
+    bars = ax.bar(population.Nk_names, values, color=color, width=bar_width)
 
     # Show values on bars
     if show_values:
         value_fontsize = value_fontsize or fontsize
         for bar in bars:
             height = bar.get_height()
-            ax.text(bar.get_x() + bar.get_width()/2, height,
-                   format(height, fmt),
-                   ha='center', va='bottom',
-                   fontsize=value_fontsize)
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                height,
+                format(height, fmt),
+                ha="center",
+                va="bottom",
+                fontsize=value_fontsize,
+            )
 
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", linewidth=0.3, alpha=0.5)
-    
+
     # Labels
     if ylabel is None:
         ylabel = "Population (%)" if show_perc else "Population"
     ax.set_ylabel(ylabel, fontsize=fontsize)
     ax.set_xlabel(xlabel, fontsize=fontsize)
-    
+
     # Title
     if title is None:
         title = f"Population Distribution - {population.name}"
     ax.set_title(title, fontsize=fontsize + 2, pad=20)
-    
+
     # Tick formatting
-    ax.tick_params(axis='both', which='major', labelsize=fontsize)
-    plt.setp(ax.get_xticklabels(), rotation=rotation, ha='right')
-    
+    ax.tick_params(axis="both", which="major", labelsize=fontsize)
+    plt.setp(ax.get_xticklabels(), rotation=rotation, ha="right")
+
     # Adjust y-axis to start at 0
     ax.set_ylim(bottom=0)
-    
+
     # Add some padding above highest bar for values
     if show_values:
         ax.set_ylim(top=ax.get_ylim()[1] * 1.1)
-    
+
     # Adjust layout
     plt.tight_layout()
-    
+
     return ax
 
 
-def plot_spectral_radius(epimodel: Any, 
-                        ax: Optional[plt.Axes] = None, 
-                        title: Optional[str] = None, 
-                        color: str = "k", 
-                        show_perc: bool = False, 
-                        layer: str = "overall", 
-                        show_interventions: bool = True, 
-                        interventions_palette: str = "Dark2", 
-                        interventions_colors: Optional[List[str]] = None,
-                        fontsize: int = 10,
-                        date_format: str = '%Y-%m-%d',
-                        ylabel: Optional[str] = None,
-                        xlabel: str = "Date",
-                        show_grid: bool = True,
-                        alpha: float = 0.2,
-                        legend_loc: str = "upper left") -> plt.Axes:
+def plot_spectral_radius(
+    epimodel: Any,
+    ax: Optional[plt.Axes] = None,
+    title: Optional[str] = None,
+    color: str = "k",
+    show_perc: bool = False,
+    layer: str = "overall",
+    show_interventions: bool = True,
+    interventions_palette: str = "Dark2",
+    interventions_colors: Optional[List[str]] = None,
+    fontsize: int = 10,
+    date_format: str = "%Y-%m-%d",
+    ylabel: Optional[str] = None,
+    xlabel: str = "Date",
+    show_grid: bool = True,
+    alpha: float = 0.2,
+    legend_loc: str = "upper left",
+) -> plt.Axes:
     """
     Plots the spectral radius of the contact matrices over time.
 
@@ -688,9 +742,11 @@ def plot_spectral_radius(epimodel: Any,
     """
     if len(epimodel.Cs) == 0:
         raise ValueError("No contact matrices defined over time")
-    
+
     if layer not in epimodel.population.layers + ["overall"]:
-        raise ValueError(f"Layer '{layer}' not found. Available layers: {epimodel.population.layers + ['overall']}")
+        raise ValueError(
+            f"Layer '{layer}' not found. Available layers: {epimodel.population.layers + ['overall']}"
+        )
 
     # Create figure if needed
     if ax is None:
@@ -699,40 +755,53 @@ def plot_spectral_radius(epimodel: Any,
     # Compute spectral radius
     dates = list(epimodel.Cs.keys())
     rho = [np.linalg.eigvals(epimodel.Cs[date][layer]).max().real for date in dates]
-    
+
     # Normalize and convert to percentage if requested
     if show_perc:
         rho = np.array(rho) / rho[0]
         rho = (rho - 1) * 100
 
     # Plot spectral radius
-    ax.plot(dates, rho, color=color, label='Spectral radius', linewidth=2)
+    ax.plot(dates, rho, color=color, label="Spectral radius", linewidth=2)
 
     # Show interventions if requested
-    if show_interventions and hasattr(epimodel, 'interventions'):
+    if show_interventions and hasattr(epimodel, "interventions"):
         # Select interventions for the layer (if layer is "overall", all interventions are selected)
         if layer == "overall":
             interventions = epimodel.interventions
         else:
-            interventions = [intervention for intervention in epimodel.interventions if intervention["layer"] == layer]
+            interventions = [
+                intervention
+                for intervention in epimodel.interventions
+                if intervention["layer"] == layer
+            ]
 
-        # get colors    
-        colors = (interventions_colors if interventions_colors 
-                 else sns.color_palette(interventions_palette, len(interventions)))
-        
+        # get colors
+        colors = (
+            interventions_colors
+            if interventions_colors
+            else sns.color_palette(interventions_palette, len(interventions))
+        )
+
         for intervention, color in zip(interventions, colors):
-            ax.axvspan(intervention["start_date"], intervention["end_date"], alpha=alpha, color=color, label=intervention["name"])
+            ax.axvspan(
+                intervention["start_date"],
+                intervention["end_date"],
+                alpha=alpha,
+                color=color,
+                label=intervention["name"],
+            )
 
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", alpha=0.3)
 
     # Format dates
     ax.xaxis.set_major_formatter(mdates.DateFormatter(date_format))
-    plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
 
     # Labels
     if ylabel is None:
@@ -745,8 +814,8 @@ def plot_spectral_radius(epimodel: Any,
     ax.set_title(title, fontsize=fontsize + 2, pad=20)
 
     # Legend if interventions are shown
-    if show_interventions and hasattr(epimodel, 'interventions'):
-        ax.legend(loc=legend_loc, fontsize=fontsize-2)
+    if show_interventions and hasattr(epimodel, "interventions"):
+        ax.legend(loc=legend_loc, fontsize=fontsize - 2)
 
     # Adjust layout
     plt.tight_layout()
@@ -754,25 +823,27 @@ def plot_spectral_radius(epimodel: Any,
     return ax
 
 
-def plot_distance_distribution(distances: Union[np.ndarray, List[float], pd.Series],
-                             ax: Optional[plt.Axes] = None,
-                             kind: str = "hist",
-                             color: str = "dodgerblue",
-                             xlabel: Optional[str] = None,
-                             ylabel: Optional[str] = None,
-                             title: Optional[str] = None,
-                             fontsize: int = 10,
-                             show_grid: bool = True,
-                             show_kde: bool = True,
-                             show_rug: bool = False,
-                             figsize: Tuple[int, int] = (10, 4),
-                             xlim: Optional[Tuple[float, float]] = None,
-                             ylim: Optional[Tuple[float, float]] = None,
-                             stat: str = "density",
-                             bins: Union[int, str] = "auto",
-                             alpha: float = 0.4,
-                             vertical_lines: Optional[Dict[str, Dict[str, Any]]] = None,
-                             **kwargs) -> plt.Axes:
+def plot_distance_distribution(
+    distances: Union[np.ndarray, List[float], pd.Series],
+    ax: Optional[plt.Axes] = None,
+    kind: str = "hist",
+    color: str = "dodgerblue",
+    xlabel: Optional[str] = None,
+    ylabel: Optional[str] = None,
+    title: Optional[str] = None,
+    fontsize: int = 10,
+    show_grid: bool = True,
+    show_kde: bool = True,
+    show_rug: bool = False,
+    figsize: Tuple[int, int] = (10, 4),
+    xlim: Optional[Tuple[float, float]] = None,
+    ylim: Optional[Tuple[float, float]] = None,
+    stat: str = "density",
+    bins: Union[int, str] = "auto",
+    alpha: float = 0.4,
+    vertical_lines: Optional[Dict[str, Dict[str, Any]]] = None,
+    **kwargs,
+) -> plt.Axes:
     """
     Plots the distribution of distances/errors from calibration.
 
@@ -825,56 +896,53 @@ def plot_distance_distribution(distances: Union[np.ndarray, List[float], pd.Seri
         ylabel = {
             "hist": "Density" if stat == "density" else "Count",
             "kde": "Density",
-            "ecdf": "Cumulative Probability"
+            "ecdf": "Cumulative Probability",
         }.get(kind, "")
 
     # Plot based on kind
     if kind == "hist":
-        sns.histplot(data=distances,
-                    ax=ax,
-                    color=color,
-                    stat=stat,
-                    bins=bins,
-                    alpha=alpha,
-                    kde=show_kde,
-                    **kwargs)
+        sns.histplot(
+            data=distances,
+            ax=ax,
+            color=color,
+            stat=stat,
+            bins=bins,
+            alpha=alpha,
+            kde=show_kde,
+            **kwargs,
+        )
     elif kind == "kde":
-        sns.kdeplot(data=distances,
-                   ax=ax,
-                   color=color,
-                   fill=True,
-                   alpha=alpha,
-                   **kwargs)
+        sns.kdeplot(
+            data=distances, ax=ax, color=color, fill=True, alpha=alpha, **kwargs
+        )
     elif kind == "ecdf":
-        sns.ecdfplot(data=distances,
-                    ax=ax,
-                    color=color,
-                    **kwargs)
+        sns.ecdfplot(data=distances, ax=ax, color=color, **kwargs)
     else:
-        raise ValueError(f"Unknown kind for plot: {kind}. Must be 'hist', 'kde', or 'ecdf'")
+        raise ValueError(
+            f"Unknown kind for plot: {kind}. Must be 'hist', 'kde', or 'ecdf'"
+        )
 
     # Add rug plot if requested
     if show_rug:
-        sns.rugplot(data=distances,
-                   ax=ax,
-                   color=color,
-                   alpha=alpha/2)
+        sns.rugplot(data=distances, ax=ax, color=color, alpha=alpha / 2)
 
     # Add vertical lines if specified
     if vertical_lines:
         for line_specs in vertical_lines.values():
-            ax.axvline(x=line_specs['x'],
-                      color=line_specs.get('color', 'red'),
-                      linestyle=line_specs.get('linestyle', '--'),
-                      label=line_specs.get('label', None),
-                      alpha=line_specs.get('alpha', 1.0))
-            if line_specs.get('label'):
+            ax.axvline(
+                x=line_specs["x"],
+                color=line_specs.get("color", "red"),
+                linestyle=line_specs.get("linestyle", "--"),
+                label=line_specs.get("label", None),
+                alpha=line_specs.get("alpha", 1.0),
+            )
+            if line_specs.get("label"):
                 ax.legend(frameon=False)
 
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", linewidth=0.3, alpha=0.5)
 
@@ -891,7 +959,7 @@ def plot_distance_distribution(distances: Union[np.ndarray, List[float], pd.Seri
         ax.set_title(title, fontsize=fontsize + 2, pad=20)
 
     # Tick formatting
-    ax.tick_params(axis='both', which='major', labelsize=fontsize-2)
+    ax.tick_params(axis="both", which="major", labelsize=fontsize - 2)
 
     # Adjust layout
     plt.tight_layout()
@@ -899,23 +967,25 @@ def plot_distance_distribution(distances: Union[np.ndarray, List[float], pd.Seri
     return ax
 
 
-def plot_trajectories(stacked: Dict[str, np.ndarray],
-                     columns: Union[List[str], str],
-                     data: Optional[pd.DataFrame] = None,
-                     ax: Optional[plt.Axes] = None,
-                     show_data: bool = False,
-                     alpha: float = 0.1,
-                     title: str = "",
-                     ylabel: str = "",
-                     xlabel: str = "",
-                     show_legend: bool = True,
-                     legend_loc: str = "upper left",
-                     palette: str = "Dark2",
-                     colors: Optional[Union[List[str], str]] = None,
-                     labels: Optional[Union[List[str], str]] = None,
-                     y_scale: str = "linear",
-                     show_grid: bool = True,
-                     dates: Optional[np.ndarray] = None) -> plt.Axes:
+def plot_trajectories(
+    stacked: Dict[str, np.ndarray],
+    columns: Union[List[str], str],
+    data: Optional[pd.DataFrame] = None,
+    ax: Optional[plt.Axes] = None,
+    show_data: bool = False,
+    alpha: float = 0.1,
+    title: str = "",
+    ylabel: str = "",
+    xlabel: str = "",
+    show_legend: bool = True,
+    legend_loc: str = "upper left",
+    palette: str = "Dark2",
+    colors: Optional[Union[List[str], str]] = None,
+    labels: Optional[Union[List[str], str]] = None,
+    y_scale: str = "linear",
+    show_grid: bool = True,
+    dates: Optional[np.ndarray] = None,
+) -> plt.Axes:
     """
     Plots individual trajectories over time with optional observed data.
 
@@ -945,7 +1015,7 @@ def plot_trajectories(stacked: Dict[str, np.ndarray],
         columns = [columns]
 
     if ax is None:
-        _, ax = plt.subplots(dpi=300, figsize=(10,4))
+        _, ax = plt.subplots(dpi=300, figsize=(10, 4))
 
     if colors is None:
         colors = sns.color_palette(palette, len(columns))
@@ -967,22 +1037,30 @@ def plot_trajectories(stacked: Dict[str, np.ndarray],
     pleg = []
     for column, color, label in zip(columns, colors, labels):
         trajectories = stacked[column]
-        
+
         # Plot individual trajectories
         for traj in trajectories:
             line = ax.plot(x, traj, color=color, alpha=alpha, linewidth=0.5, zorder=1)
-        
+
         # Plot median trajectory with higher alpha
         mean_traj = np.median(trajectories, axis=0)
-        line, = ax.plot(x, mean_traj, color=color, alpha=1.0, 
-                       linewidth=2, label=label, zorder=2)
+        (line,) = ax.plot(
+            x, mean_traj, color=color, alpha=1.0, linewidth=2, label=label, zorder=2
+        )
         pleg.append(line)
 
     handles_data = []
     if show_data and data is not None:
         data_colors = get_black_to_grey(len(columns))
         for column, data_color, label in zip(columns, data_colors, labels):
-            p_actual = ax.scatter(x, data[column], s=10, color=data_color, zorder=3, label=f"observed ({label})")
+            p_actual = ax.scatter(
+                x,
+                data[column],
+                s=10,
+                color=data_color,
+                zorder=3,
+                label=f"observed ({label})",
+            )
             if show_legend:
                 pleg.append(p_actual)
                 handles_data.append(f"observed ({label})")
@@ -990,21 +1068,24 @@ def plot_trajectories(stacked: Dict[str, np.ndarray],
     # Style improvements
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    
+
     if show_grid:
         ax.grid(axis="y", linestyle="--", linewidth=0.3, alpha=0.5, zorder=0)
-    
+
     # Labels and formatting
     ax.set_title(title)
     ax.set_ylabel(ylabel)
     ax.set_xlabel(xlabel)
     ax.set_yscale(y_scale)
-    
-    if show_legend and pleg:
-        ax.legend(pleg, labels + (handles_data if show_data and data is not None else []), 
-                 loc=legend_loc, frameon=False)
-    
-    plt.tight_layout()
-    
-    return ax
 
+    if show_legend and pleg:
+        ax.legend(
+            pleg,
+            labels + (handles_data if show_data and data is not None else []),
+            loc=legend_loc,
+            frameon=False,
+        )
+
+    plt.tight_layout()
+
+    return ax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,18 +49,20 @@ minversion = "6.0"
 addopts = "--strict-markers"
 testpaths = ["tests"]  # Directory containing tests
 
-[tool.pylint]
-# Pylint configuration 
-disable = [
-    "C0103",  # Disable specific linting rules
-]
-
-[tool.black]
-# Black configuration 
+[tool.ruff]
+# Ruff configuration
 line-length = 88
-target-version = ["py37"]
+exclude = ["**/*.ipynb"]
 
+[tool.ruff.lint]
+select = [
+    "PLE", # pylint errors
+    "PLW", # pylint warnings
+    "E", # pycodestyle
+    "F", # pyflakes
+    "I" # isort
+]
+ignore = ["E501", "E741"]
 
-[tool.isort]
-# isort configuration (for import sorting)
-profile = "black"
+[tool.ruff.format]
+quote-style = "double"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,26 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Read the README file to use as the long description (optional)
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="epydemix",  
-    version="1.0.2",  
-    author="The Epydemix Developers",  
-    author_email="epydemix@isi.it",  
-    description="A Python package for epidemic modeling, simulation, and calibration",  
-    long_description=long_description,  
-    long_description_content_type="text/markdown",  
-    url="https://github.com/epistorm/epydemix", 
-    packages=find_packages(),  
-    include_package_data=True,  
+    name="epydemix",
+    version="1.0.2",
+    author="The Epydemix Developers",
+    author_email="epydemix@isi.it",
+    description="A Python package for epidemic modeling, simulation, and calibration",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/epistorm/epydemix",
+    packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", 
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8', 
+    python_requires=">=3.8",
     install_requires=[
         "evalidate>=2.0.3",
         "matplotlib>=3.7.3",
@@ -28,10 +28,9 @@ setup(
         "pandas>=2.0.3",
         "scipy>=1.10.1",
         "seaborn>=0.13.2",
-        "setuptools>=68.2.0"
+        "setuptools>=68.2.0",
     ],
     entry_points={
-        'console_scripts': [
-        ],
+        "console_scripts": [],
     },
 )

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,26 +1,30 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
-import numpy as np
-import pandas as pd
 from datetime import timedelta
+
+import numpy as np
 from scipy import stats
+
 from epydemix.calibration.abc import ABCSampler
+from epydemix.model import simulate
 from epydemix.model.predefined_models import create_sir
 from epydemix.population import Population
-from epydemix.model import simulate
+
 
 @pytest.fixture
 def mock_simulation_function():
     """Fixture providing a simple mock simulation function"""
+
     def simulate(params):
         beta = params.get("beta", 0.3)
         gamma = params.get("gamma", 0.1)
         # Simple deterministic SIR output
-        return {
-            "data": np.array([100 * np.exp(-beta * gamma * t) for t in range(10)])
-        }
+        return {"data": np.array([100 * np.exp(-beta * gamma * t) for t in range(10)])}
+
     return simulate
+
 
 @pytest.fixture
 def basic_abc_sampler(mock_simulation_function):
@@ -28,9 +32,9 @@ def basic_abc_sampler(mock_simulation_function):
     # Define priors
     priors = {
         "beta": stats.uniform(0.1, 0.5),  # U(0.1, 0.6)
-        "gamma": stats.uniform(0.05, 0.2)  # U(0.05, 0.25)
+        "gamma": stats.uniform(0.05, 0.2),  # U(0.05, 0.25)
     }
-    
+
     # Create sampler
     return ABCSampler(
         simulation_function=mock_simulation_function,
@@ -39,6 +43,7 @@ def basic_abc_sampler(mock_simulation_function):
         observed_data=np.array([90, 82, 75, 68, 62, 57, 52, 48, 44, 40]),
     )
 
+
 def test_abc_initialization(basic_abc_sampler):
     """Test ABC sampler initialization"""
     assert len(basic_abc_sampler.param_names) == 2
@@ -46,24 +51,23 @@ def test_abc_initialization(basic_abc_sampler):
     assert "gamma" in basic_abc_sampler.continuous_params
     assert len(basic_abc_sampler.discrete_params) == 0
 
+
 def test_abc_rejection(basic_abc_sampler):
     """Test ABC rejection sampling"""
     results = basic_abc_sampler.calibrate(
-        strategy="rejection",
-        epsilon=100.0,
-        num_particles=10,
-        verbose=False
+        strategy="rejection", epsilon=100.0, num_particles=10, verbose=False
     )
-    
+
     # Check results structure
     assert len(results.posterior_distributions) == 1
     posterior = results.posterior_distributions[0]
     assert "beta" in posterior.columns
     assert "gamma" in posterior.columns
-    
+
     # Check parameter ranges
     assert np.all((0.1 <= posterior["beta"]) & (posterior["beta"] <= 0.6))
     assert np.all((0.05 <= posterior["gamma"]) & (posterior["gamma"] <= 0.25))
+
 
 def test_abc_smc(basic_abc_sampler):
     """Test ABC Sequential Monte Carlo"""
@@ -72,37 +76,35 @@ def test_abc_smc(basic_abc_sampler):
         num_particles=10,
         num_generations=3,
         epsilon_quantile_level=0.5,
-        verbose=False
+        verbose=False,
     )
-    
+
     # Check results structure
     assert len(results.posterior_distributions) == 3  # One per generation
-    
+
     # Check parameter ranges in final generation
     final_posterior = results.get_posterior_distribution()
     assert np.all((0.1 <= final_posterior["beta"]) & (final_posterior["beta"] <= 0.6))
-    assert np.all((0.05 <= final_posterior["gamma"]) & (final_posterior["gamma"] <= 0.25))
+    assert np.all(
+        (0.05 <= final_posterior["gamma"]) & (final_posterior["gamma"] <= 0.25)
+    )
 
 
 def test_abc_with_real_model():
     """Test ABC with a real SIR model"""
     # Create SIR model
     model = create_sir(transmission_rate=0.3, recovery_rate=0.1)
-    
+
     # Set up population
     pop = Population()
     pop.add_population([10000])
     pop.add_contact_matrix(np.array([[1.0]]))
     model.set_population(pop)
-    
+
     # Generate synthetic data
-    true_params = {
-        "beta": 0.3,
-        "gamma": 0.1
-    }
+    true_params = {"beta": 0.3, "gamma": 0.1}
     model.add_parameter(parameters_dict=true_params)
 
-    
     synthetic_data = simulate(
         epimodel=model,
         start_date="2023-01-01",
@@ -110,39 +112,39 @@ def test_abc_with_real_model():
         initial_conditions_dict={
             "Susceptible": np.array([9900]),
             "Infected": np.array([100]),
-            "Recovered": np.array([0])
-        }
+            "Recovered": np.array([0]),
+        },
     )
 
-    def simulate_wrapper(parameters): 
+    def simulate_wrapper(parameters):
         results = simulate(**parameters)
         return {"data": results.compartments["Infected_total"]}
-    
+
     # Set up ABC sampler
     sampler = ABCSampler(
         simulation_function=simulate_wrapper,
         priors={
             "transmission_rate": stats.uniform(0.1, 0.5),
-            "recovery_rate": stats.uniform(0.05, 0.2)
+            "recovery_rate": stats.uniform(0.05, 0.2),
         },
-        parameters=dict(epimodel=model,
-                        start_date="2023-01-01",
-                        end_date="2023-01-10",
-                        initial_conditions_dict={
-                            "Susceptible": np.array([9900]),
-                            "Infected": np.array([100]),
-                            "Recovered": np.array([0])
-                            }),
-        observed_data=synthetic_data.compartments["Infected_total"]
+        parameters=dict(
+            epimodel=model,
+            start_date="2023-01-01",
+            end_date="2023-01-10",
+            initial_conditions_dict={
+                "Susceptible": np.array([9900]),
+                "Infected": np.array([100]),
+                "Recovered": np.array([0]),
+            },
+        ),
+        observed_data=synthetic_data.compartments["Infected_total"],
     )
     # Run calibration
-    results = sampler.calibrate(
-        strategy="rejection",
-        epsilon=100,
-        num_particles=10,
-        verbose=False
+    sampler.calibrate(
+        strategy="rejection", epsilon=100, num_particles=10, verbose=False
     )
-    
+
+
 def test_abc_error_handling(basic_abc_sampler):
     """Test error handling in ABC"""
     # Test invalid strategy
@@ -158,7 +160,7 @@ def test_abc_runtime_limits(basic_abc_sampler):
         epsilon=0.1,
         num_particles=1000,
         max_time=timedelta(seconds=1),
-        verbose=False
+        verbose=False,
     )
     assert len(results.posterior_distributions) > 0
 
@@ -168,6 +170,6 @@ def test_abc_runtime_limits(basic_abc_sampler):
         epsilon=0.1,
         num_particles=1000,
         total_simulations_budget=100,
-        verbose=False
+        verbose=False,
     )
-    assert len(results.posterior_distributions) > 0 
+    assert len(results.posterior_distributions) > 0

--- a/tests/test_epimodel.py
+++ b/tests/test_epimodel.py
@@ -1,21 +1,25 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
+
 import numpy as np
-from datetime import datetime
-from pandas import Timestamp
+
 from epydemix.model.epimodel import EpiModel, stochastic_simulation
 from epydemix.population import Population
 
 # filepath: epydemix/tests/test_epimodel.py
 
+
 @pytest.fixture
 def mock_epimodel():
     model = EpiModel(
         compartments=["Susceptible", "Infected", "Recovered"],
-        parameters={"transmission_rate": 0.3, "recovery_rate": 0.1}
+        parameters={"transmission_rate": 0.3, "recovery_rate": 0.1},
     )
-    model.add_transition("Susceptible", "Infected", "mediated", ("transmission_rate", "Infected"))
+    model.add_transition(
+        "Susceptible", "Infected", "mediated", ("transmission_rate", "Infected")
+    )
     model.add_transition("Infected", "Recovered", "spontaneous", "recovery_rate")
 
     population = Population()
@@ -24,10 +28,12 @@ def mock_epimodel():
     model.set_population(population)
     return model
 
+
 @pytest.fixture
 def basic_model():
     """Basic model fixture with minimal setup"""
     return EpiModel(name="Test Model")
+
 
 def test_model_initialization():
     """Test model initialization with different parameters"""
@@ -41,11 +47,12 @@ def test_model_initialization():
     model = EpiModel(
         name="Custom Model",
         compartments=["S", "I", "R"],
-        parameters={"beta": 0.3, "gamma": 0.1}
+        parameters={"beta": 0.3, "gamma": 0.1},
     )
     assert model.name == "Custom Model"
     assert len(model.compartments) == 3
     assert len(model.parameters) == 2
+
 
 def test_compartment_management(basic_model):
     """Test adding and removing compartments"""
@@ -63,14 +70,15 @@ def test_compartment_management(basic_model):
     basic_model.clear_compartments()
     assert len(basic_model.compartments) == 0
 
+
 def test_transition_management(basic_model):
     """Test adding and removing transitions"""
     basic_model.add_compartments(["S", "I", "R"])
-    
+
     # Test adding transitions
     basic_model.add_transition("S", "I", "mediated", ("beta", "I"))
     assert len(basic_model.transitions_list) == 1
-    
+
     basic_model.add_transition("I", "R", "spontaneous", "gamma")
     assert len(basic_model.transitions_list) == 2
 
@@ -82,6 +90,7 @@ def test_transition_management(basic_model):
     basic_model.clear_transitions()
     assert len(basic_model.transitions_list) == 0
 
+
 def test_parameter_management(basic_model):
     """Test parameter management"""
     # Test adding single parameter
@@ -92,10 +101,11 @@ def test_parameter_management(basic_model):
     # Test adding multiple parameters
     basic_model.add_parameter(parameters_dict={"gamma": 0.1, "R0": 3.0})
     assert len(basic_model.parameters) == 3
-    
+
     # Test parameter deletion
     basic_model.delete_parameter("R0")
     assert "R0" not in basic_model.parameters
+
 
 def test_intervention_management(basic_model):
     """Test intervention management"""
@@ -103,28 +113,29 @@ def test_intervention_management(basic_model):
         layer_name="overall",
         start_date="2023-01-01",
         end_date="2023-02-01",
-        reduction_factor=0.5
+        reduction_factor=0.5,
     )
     assert len(basic_model.interventions) == 1
 
     # Test invalid intervention
     with pytest.raises(ValueError):
         basic_model.add_intervention(
-            layer_name="overall",
-            start_date="2023-01-01",
-            end_date="2023-02-01"
+            layer_name="overall", start_date="2023-01-01", end_date="2023-02-01"
         )
+
 
 def test_stochastic_simulation(mock_epimodel):
     """Test stochastic simulation with conservation laws"""
     T = 10
     N = 3
 
-    contact_matrices = [{"overall": mock_epimodel.population.contact_matrices["all"]} for _ in range(T)]
+    contact_matrices = [
+        {"overall": mock_epimodel.population.contact_matrices["all"]} for _ in range(T)
+    ]
     initial_conditions = np.array([[9990, 10, 0], [9990, 10, 0], [9990, 10, 0]])
     parameters = {
         "transmission_rate": np.full(T, 0.3),
-        "recovery_rate": np.full(T, 0.1)
+        "recovery_rate": np.full(T, 0.1),
     }
 
     compartments_evolution, transitions_evolution = stochastic_simulation(
@@ -133,7 +144,7 @@ def test_stochastic_simulation(mock_epimodel):
         epimodel=mock_epimodel,
         parameters=parameters,
         initial_conditions=initial_conditions,
-        dt=1.0
+        dt=1.0,
     )
 
     # Test shape of outputs
@@ -142,10 +153,7 @@ def test_stochastic_simulation(mock_epimodel):
 
     # Test population conservation
     for t in range(T):
-        assert np.isclose(
-            np.sum(compartments_evolution[t]), 
-            np.sum(initial_conditions)
-        )
+        assert np.isclose(np.sum(compartments_evolution[t]), np.sum(initial_conditions))
 
     # Test non-negative populations
     assert np.all(compartments_evolution >= 0)
@@ -154,12 +162,13 @@ def test_stochastic_simulation(mock_epimodel):
 
 def test_stochastic_simulation_invalid_initial_conditions(mock_epimodel):
     T = 10
-    N = 3
-    contact_matrices = [{"overall": mock_epimodel.population.contact_matrices["all"]} for _ in range(T)]
+    contact_matrices = [
+        {"overall": mock_epimodel.population.contact_matrices["all"]} for _ in range(T)
+    ]
     initial_conditions = np.array([[1000, 0], [0, 10], [0, 0]])  # Invalid shape
     parameters = {
         "transmission_rate": np.full(T, 0.3),
-        "recovery_rate": np.full(T, 0.1)
+        "recovery_rate": np.full(T, 0.1),
     }
     dt = 1.0
 
@@ -170,5 +179,5 @@ def test_stochastic_simulation_invalid_initial_conditions(mock_epimodel):
             epimodel=mock_epimodel,
             parameters=parameters,
             initial_conditions=initial_conditions,
-            dt=dt
+            dt=dt,
         )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,13 +1,8 @@
-import pytest
 import numpy as np
-from epydemix.calibration.metrics import (
-    rmse,
-    mae,
-    mape,
-    wmape,
-    ae,
-    validate_data
-)
+import pytest
+
+from epydemix.calibration.metrics import ae, mae, mape, rmse, validate_data, wmape
+
 
 @pytest.fixture
 def sample_data():
@@ -15,6 +10,7 @@ def sample_data():
     observed = {"data": np.array([10, 20, 30, 40, 50])}
     simulated = {"data": np.array([12, 18, 32, 38, 52])}
     return observed, simulated
+
 
 def test_validate_data():
     """Test data validation function"""
@@ -24,118 +20,128 @@ def test_validate_data():
     obs, sim = validate_data(observed, simulated)
     assert np.array_equal(obs, observed["data"])
     assert np.array_equal(sim, simulated["data"])
-    
+
     # Test missing key
-    with pytest.raises(ValueError, match="Both input Dictionaries must contain the key 'data'"):
+    with pytest.raises(
+        ValueError, match="Both input Dictionaries must contain the key 'data'"
+    ):
         validate_data({"wrong_key": [1, 2, 3]}, simulated)
-    
+
     # Test shape mismatch
-    with pytest.raises(ValueError, match="The shapes of observed and simulated data arrays must match"):
-        validate_data(
-            {"data": np.array([1, 2, 3])},
-            {"data": np.array([1, 2])}
-        )
+    with pytest.raises(
+        ValueError, match="The shapes of observed and simulated data arrays must match"
+    ):
+        validate_data({"data": np.array([1, 2, 3])}, {"data": np.array([1, 2])})
+
 
 def test_rmse(sample_data):
     """Test Root Mean Square Error calculation"""
     observed, simulated = sample_data
     result = rmse(observed, simulated)
-    
+
     # Manual calculation for verification
     expected = np.sqrt(np.mean((observed["data"] - simulated["data"]) ** 2))
     assert np.isclose(result, expected)
-    
+
     # Test with perfect prediction
     perfect = {"data": observed["data"]}
     assert rmse(observed, perfect) == 0
+
 
 def test_mae(sample_data):
     """Test Mean Absolute Error calculation"""
     observed, simulated = sample_data
     result = mae(observed, simulated)
-    
+
     # Manual calculation for verification
     expected = np.mean(np.abs(observed["data"] - simulated["data"]))
     assert np.isclose(result, expected)
-    
+
     # Test with perfect prediction
     perfect = {"data": observed["data"]}
     assert mae(observed, perfect) == 0
+
 
 def test_mape(sample_data):
     """Test Mean Absolute Percentage Error calculation"""
     observed, simulated = sample_data
     result = mape(observed, simulated)
-    
+
     # Manual calculation for verification
-    expected = np.mean(np.abs((observed["data"] - simulated["data"]) / observed["data"]))
+    expected = np.mean(
+        np.abs((observed["data"] - simulated["data"]) / observed["data"])
+    )
     assert np.isclose(result, expected)
-    
+
     # Test with perfect prediction
     perfect = {"data": observed["data"]}
     assert mape(observed, perfect) == 0
-    
+
 
 def test_wmape(sample_data):
     """Test Weighted Mean Absolute Percentage Error calculation"""
     observed, simulated = sample_data
     result = wmape(observed, simulated)
-    
+
     # Manual calculation for verification
-    expected = np.sum(np.abs(observed["data"] - simulated["data"])) / np.sum(np.abs(observed["data"]))
+    expected = np.sum(np.abs(observed["data"] - simulated["data"])) / np.sum(
+        np.abs(observed["data"])
+    )
     assert np.isclose(result, expected)
-    
+
     # Test with perfect prediction
     perfect = {"data": observed["data"]}
     assert wmape(observed, perfect) == 0
-    
+
 
 def test_ae(sample_data):
     """Test Absolute Error calculation"""
     observed, simulated = sample_data
     result = ae(observed, simulated)
-    
+
     # Manual calculation for verification
     expected = np.abs(observed["data"] - simulated["data"])
     assert np.array_equal(result, expected)
-    
+
     # Test with perfect prediction
     perfect = {"data": observed["data"]}
     assert np.all(ae(observed, perfect) == 0)
+
 
 def test_edge_cases():
     """Test edge cases for all metrics"""
     # Test with single value
     obs = {"data": np.array([1])}
     sim = {"data": np.array([1.1])}
-    
+
     assert isinstance(rmse(obs, sim), float)
     assert isinstance(mae(obs, sim), float)
     assert isinstance(mape(obs, sim), float)
     assert isinstance(wmape(obs, sim), float)
     assert isinstance(ae(obs, sim), np.ndarray)
-    
+
     # Test with large values
     obs = {"data": np.array([1e6, 2e6])}
     sim = {"data": np.array([1.1e6, 1.9e6])}
-    
+
     assert np.isfinite(rmse(obs, sim))
     assert np.isfinite(mae(obs, sim))
     assert np.isfinite(mape(obs, sim))
     assert np.isfinite(wmape(obs, sim))
     assert np.all(np.isfinite(ae(obs, sim)))
 
+
 def test_metric_properties(sample_data):
     """Test mathematical properties of metrics"""
     observed, simulated = sample_data
-    
+
     # Test non-negativity
     assert rmse(observed, simulated) >= 0
     assert mae(observed, simulated) >= 0
     assert mape(observed, simulated) >= 0
     assert wmape(observed, simulated) >= 0
     assert np.all(ae(observed, simulated) >= 0)
-    
+
     # Test triangle inequality for MAE
     third = {"data": np.array([11, 19, 31, 39, 51])}
-    assert mae(observed, simulated) <= mae(observed, third) + mae(third, simulated) 
+    assert mae(observed, simulated) <= mae(observed, third) + mae(third, simulated)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,38 +1,48 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
+
 from epydemix.population import Population
 from epydemix.visualization.plotting import (
-    plot_quantiles,
-    plot_trajectories,
     get_timeseries_data,
+    plot_contact_matrix,
+    plot_distance_distribution,
+    plot_population,
     plot_posterior_distribution,
     plot_posterior_distribution_2d,
-    plot_population,
-    plot_contact_matrix,
-    plot_distance_distribution, 
-    plot_spectral_radius
+    plot_quantiles,
+    plot_trajectories,
 )
+
 
 @pytest.fixture
 def mock_quantiles_data():
     """Fixture providing mock quantiles data"""
     dates = pd.date_range("2023-01-01", "2023-01-10")
     data = []
-    
+
     for q in [0.05, 0.5, 0.95]:
         for date in dates:
-            data.append({
-                "date": date,
-                "I_total": 100 * np.exp(-0.1 * (date - dates[0]).days) * (1 + 0.2 * (q - 0.5)),
-                "S_total": 900 - 100 * np.exp(-0.1 * (date - dates[0]).days) * (1 + 0.2 * (q - 0.5)),
-                "quantile": q
-            })
-    
+            data.append(
+                {
+                    "date": date,
+                    "I_total": 100
+                    * np.exp(-0.1 * (date - dates[0]).days)
+                    * (1 + 0.2 * (q - 0.5)),
+                    "S_total": 900
+                    - 100
+                    * np.exp(-0.1 * (date - dates[0]).days)
+                    * (1 + 0.2 * (q - 0.5)),
+                    "quantile": q,
+                }
+            )
+
     return pd.DataFrame(data)
+
 
 @pytest.fixture
 def mock_trajectories_data():
@@ -42,44 +52,56 @@ def mock_trajectories_data():
         "I_total": np.random.normal(
             loc=np.exp(-0.1 * np.arange(len(dates))),
             scale=0.1,
-            size=(10, len(dates))  # 10 trajectories
-        ) * 100,
-        "S_total": 1000 - np.random.normal(
-            loc=np.exp(-0.1 * np.arange(len(dates))),
-            scale=0.1,
-            size=(10, len(dates))
-        ) * 100
+            size=(10, len(dates)),  # 10 trajectories
+        )
+        * 100,
+        "S_total": 1000
+        - np.random.normal(
+            loc=np.exp(-0.1 * np.arange(len(dates))), scale=0.1, size=(10, len(dates))
+        )
+        * 100,
     }
     return trajectories, dates
+
 
 @pytest.fixture
 def mock_observed_data():
     """Fixture providing mock observed data"""
     dates = pd.date_range("2023-01-01", "2023-01-10")
-    return pd.DataFrame({
-        "date": dates,
-        "I_total": 100 * np.exp(-0.1 * np.arange(len(dates))) + np.random.normal(0, 5, len(dates))
-    })
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "I_total": 100 * np.exp(-0.1 * np.arange(len(dates)))
+            + np.random.normal(0, 5, len(dates)),
+        }
+    )
+
 
 @pytest.fixture
 def mock_posterior_data():
     """Fixture providing mock posterior distribution data"""
     n_samples = 1000
-    posterior_data = pd.DataFrame({
-        'transmission_rate': np.random.normal(0.3, 0.05, n_samples),
-        'recovery_rate': np.random.normal(0.1, 0.02, n_samples),
-        'R0': np.random.normal(3.0, 0.5, n_samples)
-    })
+    posterior_data = pd.DataFrame(
+        {
+            "transmission_rate": np.random.normal(0.3, 0.05, n_samples),
+            "recovery_rate": np.random.normal(0.1, 0.02, n_samples),
+            "R0": np.random.normal(3.0, 0.5, n_samples),
+        }
+    )
     return posterior_data
+
 
 @pytest.fixture
 def mock_population_data():
     """Fixture providing mock population data"""
     population = Population()
-    population.add_population(np.array([1000, 2000, 3000, 2500, 1500]), 
-                              ["0-4", "5-14", "15-44", "45-64", "65+"])
-    population.add_contact_matrix(np.random.random((5,5)))
+    population.add_population(
+        np.array([1000, 2000, 3000, 2500, 1500]),
+        ["0-4", "5-14", "15-44", "45-64", "65+"],
+    )
+    population.add_contact_matrix(np.random.random((5, 5)))
     return population
+
 
 @pytest.fixture
 def mock_distance_data():
@@ -90,6 +112,7 @@ def mock_distance_data():
     weights = np.random.uniform(0.5, 1.5, size=n_points)
     return distances, weights
 
+
 def test_get_timeseries_data(mock_quantiles_data):
     """Test timeseries data extraction"""
     data = get_timeseries_data(mock_quantiles_data, "I_total", 0.5)
@@ -98,10 +121,11 @@ def test_get_timeseries_data(mock_quantiles_data):
     assert "I_total" in data.columns
     assert len(data) == 10  # 10 days of data
 
+
 def test_plot_quantiles(mock_quantiles_data, mock_observed_data):
     """Test quantile plotting"""
     fig, ax = plt.subplots()
-    
+
     # Basic plot test
     ax = plot_quantiles(
         df_quantiles=mock_quantiles_data,
@@ -110,22 +134,23 @@ def test_plot_quantiles(mock_quantiles_data, mock_observed_data):
         ax=ax,
         title="Test Plot",
         ylabel="Cases",
-        show_data=True
+        show_data=True,
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Test Plot"
     assert ax.get_ylabel() == "Cases"
     assert len(ax.lines) >= 1  # At least median line
     assert len(ax.collections) >= 1  # At least one confidence interval
-    
+
     plt.close()
+
 
 def test_plot_trajectories(mock_trajectories_data, mock_observed_data):
     """Test trajectory plotting"""
     trajectories, dates = mock_trajectories_data
     fig, ax = plt.subplots()
-    
+
     # Basic plot test
     ax = plot_trajectories(
         stacked=trajectories,
@@ -135,39 +160,41 @@ def test_plot_trajectories(mock_trajectories_data, mock_observed_data):
         ax=ax,
         title="Test Trajectories",
         ylabel="Cases",
-        show_data=True
+        show_data=True,
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Test Trajectories"
     assert ax.get_ylabel() == "Cases"
     assert len(ax.lines) >= 10  # At least 10 trajectory lines
-    
+
     plt.close()
+
 
 def test_plot_multiple_compartments(mock_quantiles_data):
     """Test plotting multiple compartments"""
     fig, ax = plt.subplots()
-    
+
     ax = plot_quantiles(
         df_quantiles=mock_quantiles_data,
         columns=["S_total", "I_total"],
         ax=ax,
         title="Multiple Compartments",
-        labels=["Susceptible", "Infected"]
+        labels=["Susceptible", "Infected"],
     )
-    
+
     # Check legend
     legend = ax.get_legend()
     assert legend is not None
     assert len(legend.get_texts()) == 2
-    
+
     plt.close()
+
 
 def test_plot_styling(mock_quantiles_data):
     """Test plot styling options"""
     fig, ax = plt.subplots()
-    
+
     ax = plot_quantiles(
         df_quantiles=mock_quantiles_data,
         columns=["I_total"],
@@ -176,94 +203,98 @@ def test_plot_styling(mock_quantiles_data):
         show_grid=True,
         ci_alpha=0.2,
         colors="red",
-        show_legend=False
+        show_legend=False,
     )
-    
+
     # Check styling
     assert ax.get_yscale() == "log"
     assert ax.yaxis.get_gridlines()[0].get_visible()
     assert ax.get_legend() is None
-    
+
     plt.close()
+
 
 def test_plot_posterior(mock_posterior_data):
     """Test posterior distribution plotting"""
     fig, ax = plt.subplots()
-    
+
     # Test basic posterior plot
     ax = plot_posterior_distribution(
         posterior=mock_posterior_data,
-        parameter='transmission_rate',
+        parameter="transmission_rate",
         ax=ax,
         title="Test Posterior",
         xlabel="Transmission Rate",
-        ylabel="Density"
+        ylabel="Density",
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Test Posterior"
     assert ax.get_xlabel() == "Transmission Rate"
     assert ax.get_ylabel() == "Density"
     assert len(ax.patches) > 0  # Should have histogram bars
-    
+
     plt.close()
+
 
 def test_plot_posterior_2d(mock_posterior_data):
     """Test 2D posterior distribution plotting"""
     fig, ax = plt.subplots()
-    
+
     # Test basic 2D posterior plot
     ax = plot_posterior_distribution_2d(
         posterior=mock_posterior_data,
-        parameter_x='transmission_rate',
-        parameter_y='recovery_rate',
+        parameter_x="transmission_rate",
+        parameter_y="recovery_rate",
         ax=ax,
         title="Test 2D Posterior",
         xlabel="Transmission Rate",
-        ylabel="Recovery Rate"
+        ylabel="Recovery Rate",
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Test 2D Posterior"
     assert ax.get_xlabel() == "Transmission Rate"
     assert ax.get_ylabel() == "Recovery Rate"
     assert len(ax.collections) > 0  # Should have scatter or contour plot
-    
+
     plt.close()
+
 
 def test_plot_population(mock_population_data):
     """Test population pyramid plotting"""
     fig, ax = plt.subplots()
     population = mock_population_data
-    
+
     # Test basic population plot
     ax = plot_population(
         population=population,
         ax=ax,
         title="Population Structure",
         xlabel="Population",
-        ylabel="Age Groups"
+        ylabel="Age Groups",
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Population Structure"
     assert ax.get_xlabel() == "Population"
     assert ax.get_ylabel() == "Age Groups"
-    
+
     # Check bars
     assert len(ax.patches) == len(population.Nk)  # Should have one bar per age group
-    
+
     # Check y-ticks (age groups)
     xtick_labels = [label.get_text() for label in ax.get_xticklabels()]
     assert all(group in xtick_labels for group in population.Nk_names)
-    
+
     plt.close()
+
 
 def test_plot_contact_matrix(mock_population_data):
     """Test contact matrix plotting"""
     fig, ax = plt.subplots()
     population = mock_population_data
-    
+
     # Test basic contact matrix plot
     ax = plot_contact_matrix(
         population=population,
@@ -271,31 +302,30 @@ def test_plot_contact_matrix(mock_population_data):
         ax=ax,
         title="Contact Matrix",
         cmap="YlOrRd",
-        show_colorbar=True
+        show_colorbar=True,
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Contact Matrix"
     assert len(ax.images) == 1  # Should have one heatmap
-    
-    
+
     # Check axis labels
     xtick_labels = [label.get_text() for label in ax.get_xticklabels()]
     ytick_labels = [label.get_text() for label in ax.get_yticklabels()]
     assert all(group in xtick_labels for group in population.Nk_names)
     assert all(group in ytick_labels for group in population.Nk_names)
 
-    
     # Check matrix dimensions
     assert ax.images[0].get_array().shape == (len(population.Nk), len(population.Nk))
-    
+
     plt.close()
+
 
 def test_plot_distance_distribution(mock_distance_data):
     """Test distance distribution plotting"""
     fig, ax = plt.subplots()
     distances, weights = mock_distance_data
-    
+
     # Test basic distance distribution plot
     ax = plot_distance_distribution(
         distances=distances,
@@ -303,17 +333,17 @@ def test_plot_distance_distribution(mock_distance_data):
         title="Distance Distribution",
         xlabel="Errors",
         ylabel="Density",
-        bins=30
+        bins=30,
     )
-    
+
     # Check plot elements
     assert ax.get_title() == "Distance Distribution"
     assert ax.get_xlabel() == "Errors"
     assert ax.get_ylabel() == "Density"
     assert len(ax.patches) == 30  # Number of histogram bins
-    
+
     # Check that histogram is normalized
     total_area = sum(patch.get_height() * patch.get_width() for patch in ax.patches)
     assert np.isclose(total_area, 1.0, rtol=1e-2)  # Should be normalized to 1
-    
+
     plt.close()

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,29 +1,31 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
 import numpy as np
 import pandas as pd
+
 from epydemix.population import Population
 from epydemix.population.population import (
-    aggregate_matrix,
     aggregate_demographic,
-    load_epydemix_population,
-    validate_population_name,
+    aggregate_matrix,
     get_available_locations,
-    get_primary_contacts_source,
+    load_epydemix_population,
+    validate_age_group_mapping,
     validate_contacts_source,
-    validate_age_group_mapping
 )
+
 
 @pytest.fixture
 def basic_population():
     """Fixture providing a basic population setup"""
     pop = Population(name="test_population")
     pop.add_population([1000, 2000, 3000], ["0-4", "5-19", "20+"])
-    pop.add_contact_matrix(np.array([[1.0, 0.5, 0.2],
-                                   [0.5, 1.0, 0.3],
-                                   [0.2, 0.3, 1.0]]), "home")
+    pop.add_contact_matrix(
+        np.array([[1.0, 0.5, 0.2], [0.5, 1.0, 0.3], [0.2, 0.3, 1.0]]), "home"
+    )
     return pop
+
 
 def test_population_initialization():
     """Test Population class initialization"""
@@ -32,21 +34,22 @@ def test_population_initialization():
     assert len(pop.Nk) == 0
     assert len(pop.contact_matrices) == 0
 
+
 def test_add_population():
     """Test adding population data"""
     pop = Population()
-    
+
     # Test adding population with names
     pop.add_population([1000, 2000], ["0-4", "5+"])
     assert np.all(np.array_equal(pop.Nk, [1000, 2000]))
     assert np.all(pop.Nk_names == ["0-4", "5+"])
-    
+
     # Test adding population without names
     pop2 = Population()
     pop2.add_population([1000, 2000])
     assert np.all(np.array_equal(pop2.Nk, [1000, 2000]))
     assert np.all(len(pop2.Nk_names) == 2)
-    
+
     # Test invalid inputs
     with pytest.raises(ValueError):
         pop.add_population([1000, 2000], ["0-4"])  # Mismatched lengths
@@ -55,109 +58,96 @@ def test_add_population():
 def test_add_contact_matrix():
     """Test adding contact matrices"""
     pop = Population()
-    
+
     # Test adding valid contact matrix
     matrix = np.array([[1.0, 0.5], [0.5, 1.0]])
     pop.add_contact_matrix(matrix, "home")
     assert "home" in pop.contact_matrices
     assert np.array_equal(pop.contact_matrices["home"], matrix)
-    
+
     # Test adding multiple matrices
     pop.add_contact_matrix(matrix, "work")
     assert len(pop.contact_matrices) == 2
-    
+
     # Test invalid inputs
     with pytest.raises(ValueError):
         pop.add_contact_matrix(np.array([1, 2, 3]))  # Not 2D
-    
+
     with pytest.raises(ValueError):
         pop.add_contact_matrix(np.array([[1, 2], [3, 4], [5, 6]]))  # Not square
-        
+
     with pytest.raises(ValueError):
         pop.add_contact_matrix(matrix, "overall")  # Reserved name
+
 
 def test_population_properties(basic_population):
     """Test population properties"""
     # Test total population
     assert basic_population.total_population == 6000
-    
+
     # Test number of groups
     assert basic_population.num_groups == 3
-    
+
     # Test contact matrix layers
     assert "home" in basic_population.contact_matrices
     assert basic_population.contact_matrices["home"].shape == (3, 3)
 
+
 def test_matrix_aggregation():
     """Test contact matrix aggregation"""
     # Setup test data
-    old_matrix = np.array([[1, 2, 3, 4],
-                          [2, 3, 4, 5],
-                          [3, 4, 5, 6],
-                          [4, 5, 6, 7]])
+    old_matrix = np.array([[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6], [4, 5, 6, 7]])
     old_pop = np.array([100, 100, 100, 100])
     new_pop = np.array([200, 200])
-    
-    age_group_mapping = {
-        "0-9": ["0-4", "5-9"],
-        "10+": ["10-14", "15+"]
-    }
-    
+
+    age_group_mapping = {"0-9": ["0-4", "5-9"], "10+": ["10-14", "15+"]}
+
     old_groups = {"0-4": 0, "5-9": 1, "10-14": 2, "15+": 3}
     new_groups = {"0-9": 0, "10+": 1}
-    
+
     # Test aggregation
     result = aggregate_matrix(
-        old_matrix,
-        old_pop,
-        new_pop,
-        age_group_mapping,
-        old_groups,
-        new_groups
+        old_matrix, old_pop, new_pop, age_group_mapping, old_groups, new_groups
     )
-    
+
     assert result.shape == (2, 2)
     assert np.all(result >= 0)
 
+
 def test_demographic_aggregation():
     """Test demographic data aggregation"""
-    data = pd.DataFrame({
-        "group_name": ["0-4", "5-9", "10-14", "15+"],
-        "value": [100, 100, 150, 150]
-    })
-    
-    grouping = {
-        "0-9": ["0-4", "5-9"],
-        "10+": ["10-14", "15+"]
-    }
-    
+    data = pd.DataFrame(
+        {"group_name": ["0-4", "5-9", "10-14", "15+"], "value": [100, 100, 150, 150]}
+    )
+
+    grouping = {"0-9": ["0-4", "5-9"], "10+": ["10-14", "15+"]}
+
     result = aggregate_demographic(data, grouping)
     assert len(result) == 2
     assert result.loc[result.group_name == "0-9", "value"].iloc[0] == 200
     assert result.loc[result.group_name == "10+", "value"].iloc[0] == 300
 
+
 def test_validation_functions():
     """Test various validation functions"""
-    
+
     # Test contacts source validation
     with pytest.raises(ValueError):
         validate_contacts_source("invalid_source", ["prem_2017", "prem_2021"])
-    
+
     # Test age group mapping validation
     with pytest.raises(ValueError):
-        validate_age_group_mapping(
-            {"0-9": ["0-4", "invalid"]},
-            ["0-4", "5-9", "10+"]
-        )
+        validate_age_group_mapping({"0-9": ["0-4", "invalid"]}, ["0-4", "5-9", "10+"])
+
 
 def test_population_repr(basic_population):
     """Test string representation of Population"""
     repr_str = str(basic_population)
     assert "test_population" in repr_str
     assert "Demographic groups: 3" in repr_str
-    assert "Contact matrices: 1" in repr_str 
+    assert "Contact matrices: 1" in repr_str
 
 
-def test_online_population_import(): 
-    population = load_epydemix_population("Italy")
+def test_online_population_import():
+    load_epydemix_population("Italy")
     get_available_locations()

--- a/tests/test_predefined_models.py
+++ b/tests/test_predefined_models.py
@@ -1,13 +1,15 @@
-import pytest
 import numpy as np
+import pytest
+
 from epydemix.model.predefined_models import (
-    load_predefined_model,
-    create_sir,
+    SUPPORTED_MODELS,
     create_seir,
+    create_sir,
     create_sis,
-    SUPPORTED_MODELS
+    load_predefined_model,
 )
 from epydemix.population import Population
+
 
 @pytest.fixture
 def basic_population():
@@ -17,127 +19,146 @@ def basic_population():
     population.add_contact_matrix(np.array([[1.0]]))  # Simple contact matrix
     return population
 
+
 def test_load_predefined_model():
     """Test loading different predefined models"""
     # Test loading each supported model
     for model_name in SUPPORTED_MODELS:
         model = load_predefined_model(model_name)
         assert model is not None
-        
+
     # Test invalid model name
     with pytest.raises(ValueError, match="Unknown predefined model"):
         load_predefined_model("INVALID_MODEL")
+
 
 def test_sir_model(basic_population):
     """Test SIR model creation and basic properties"""
     # Create model with custom rates
     beta, gamma = 0.3, 0.1
     model = create_sir(transmission_rate=beta, recovery_rate=gamma)
-    
+
     # Test structure
     assert set(model.compartments) == {"Susceptible", "Infected", "Recovered"}
     assert len(model.transitions_list) == 2
     assert model.parameters["transmission_rate"] == beta
     assert model.parameters["recovery_rate"] == gamma
-    
+
     # Test transitions
     transitions = {(t.source, t.target): t for t in model.transitions_list}
     assert ("Susceptible", "Infected") in transitions
     assert ("Infected", "Recovered") in transitions
-    
+
     # Test simulation
     model.set_population(basic_population)
     initial_conditions = {
         "Susceptible": np.array([9900]),
         "Infected": np.array([100]),
-        "Recovered": np.array([0])
+        "Recovered": np.array([0]),
     }
-    
+
     trajectory = model.run_simulations(
         start_date="2023-01-01",
         end_date="2023-01-10",
-        initial_conditions_dict=initial_conditions, 
-        Nsim=10
+        initial_conditions_dict=initial_conditions,
+        Nsim=10,
     )
-    
+
     # Check population conservation
-    total_population = [np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(axis=0) for v in trajectory.trajectories]
+    total_population = [
+        np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(
+            axis=0
+        )
+        for v in trajectory.trajectories
+    ]
     assert np.allclose(total_population, 10000)
+
 
 def test_seir_model(basic_population):
     """Test SEIR model creation and basic properties"""
     # Create model with custom rates
     beta, sigma, gamma = 0.3, 0.2, 0.1
     model = create_seir(
-        transmission_rate=beta,
-        incubation_rate=sigma,
-        recovery_rate=gamma
+        transmission_rate=beta, incubation_rate=sigma, recovery_rate=gamma
     )
-    
+
     # Test structure
-    assert set(model.compartments) == {"Susceptible", "Exposed", "Infected", "Recovered"}
+    assert set(model.compartments) == {
+        "Susceptible",
+        "Exposed",
+        "Infected",
+        "Recovered",
+    }
     assert len(model.transitions_list) == 3
     assert model.parameters["transmission_rate"] == beta
     assert model.parameters["incubation_rate"] == sigma
     assert model.parameters["recovery_rate"] == gamma
-    
+
     # Test transitions
     transitions = {(t.source, t.target): t for t in model.transitions_list}
     assert ("Susceptible", "Exposed") in transitions
     assert ("Exposed", "Infected") in transitions
     assert ("Infected", "Recovered") in transitions
-    
+
     # Test simulation
     model.set_population(basic_population)
     initial_conditions = {
         "Susceptible": np.array([9800]),
         "Exposed": np.array([100]),
         "Infected": np.array([100]),
-        "Recovered": np.array([0])
+        "Recovered": np.array([0]),
     }
-    
+
     trajectory = model.run_simulations(
         start_date="2023-01-01",
         end_date="2023-01-10",
-        initial_conditions_dict=initial_conditions, 
-        Nsim=10
+        initial_conditions_dict=initial_conditions,
+        Nsim=10,
     )
-    
+
     # Check population conservation
-    total_population = [np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(axis=0) for v in trajectory.trajectories]
+    total_population = [
+        np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(
+            axis=0
+        )
+        for v in trajectory.trajectories
+    ]
     assert np.allclose(total_population, 10000)
+
 
 def test_sis_model(basic_population):
     """Test SIS model creation and basic properties"""
     # Create model with custom rates
     beta, gamma = 0.3, 0.1
     model = create_sis(transmission_rate=beta, recovery_rate=gamma)
-    
+
     # Test structure
     assert set(model.compartments) == {"Susceptible", "Infected"}
     assert len(model.transitions_list) == 2
     assert model.parameters["transmission_rate"] == beta
     assert model.parameters["recovery_rate"] == gamma
-    
+
     # Test transitions
     transitions = {(t.source, t.target): t for t in model.transitions_list}
     assert ("Susceptible", "Infected") in transitions
     assert ("Infected", "Susceptible") in transitions  # Note: returns to Susceptible
-    
+
     # Test simulation
     model.set_population(basic_population)
-    initial_conditions = {
-        "Susceptible": np.array([9900]),
-        "Infected": np.array([100])
-    }
-    
+    initial_conditions = {"Susceptible": np.array([9900]), "Infected": np.array([100])}
+
     trajectory = model.run_simulations(
         start_date="2023-01-01",
         end_date="2023-01-10",
-        initial_conditions_dict=initial_conditions, 
-        Nsim=10
+        initial_conditions_dict=initial_conditions,
+        Nsim=10,
     )
-    
+
     # Check population conservation
-    total_population = [np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(axis=0) for v in trajectory.trajectories]
+    total_population = [
+        np.array([v.compartments[c] for c in v.compartments if "total" in c]).sum(
+            axis=0
+        )
+        for v in trajectory.trajectories
+    ]
     assert np.allclose(total_population, 10000)

--- a/tests/test_tutorial1.py
+++ b/tests/test_tutorial1.py
@@ -1,36 +1,49 @@
-import pytest
 import matplotlib
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
 import matplotlib.pyplot as plt
+
 from epydemix import EpiModel
 from epydemix.visualization import plot_quantiles, plot_trajectories
 
-def test_model_definition_and_simulation(): 
+
+def test_model_definition_and_simulation():
     # Defining a basic SIR model
     sir_model = EpiModel(
-        name='SIR Model',
-        compartments=['S', 'I', 'R'],  # Susceptible, Infected, Recovered
+        name="SIR Model",
+        compartments=["S", "I", "R"],  # Susceptible, Infected, Recovered
     )
 
     # Defining the transitions
-    sir_model.add_transition(source='S', target='I', params=(0.3, "I"), kind='mediated')
-    sir_model.add_transition(source='I', target='R', params=0.1, kind='spontaneous')
+    sir_model.add_transition(source="S", target="I", params=(0.3, "I"), kind="mediated")
+    sir_model.add_transition(source="I", target="R", params=0.1, kind="spontaneous")
 
     print(sir_model)
 
     sir_results = sir_model.run_simulations(
-                                    start_date="2024-01-01",
-                                    end_date="2024-04-10", 
-                                    Nsim=5)
+        start_date="2024-01-01", end_date="2024-04-10", Nsim=5
+    )
 
     df_quantiles_comps = sir_results.get_quantiles_compartments()
-    ax = plot_quantiles(df_quantiles_comps, columns=["I_total", "S_total", "R_total"], title='SIR Model Simulation (Compartments, Quantiles)')
+    plot_quantiles(
+        df_quantiles_comps,
+        columns=["I_total", "S_total", "R_total"],
+        title="SIR Model Simulation (Compartments, Quantiles)",
+    )
     plt.close()
 
     df_quantiles_tr = sir_results.get_quantiles_transitions()
-    ax = plot_quantiles(df_quantiles_tr, columns=["S_to_I_total", "I_to_R_total"], title='SIR Model Simulation (Transitions, Quantiles)')
+    plot_quantiles(
+        df_quantiles_tr,
+        columns=["S_to_I_total", "I_to_R_total"],
+        title="SIR Model Simulation (Transitions, Quantiles)",
+    )
     plt.close()
 
     trajectories_comp = sir_results.get_stacked_compartments()
-    ax = plot_trajectories(trajectories_comp, columns=["I_total", "S_total", "R_total"], title='SIR Model Simulation (Compartments, Trajectories)')
+    plot_trajectories(
+        trajectories_comp,
+        columns=["I_total", "S_total", "R_total"],
+        title="SIR Model Simulation (Compartments, Trajectories)",
+    )
     plt.close()

--- a/tests/test_tutorial2.py
+++ b/tests/test_tutorial2.py
@@ -1,59 +1,94 @@
-import pytest
-from epydemix import load_predefined_model
-from epydemix.population import Population, load_epydemix_population
-from epydemix.visualization import plot_contact_matrix, plot_population, plot_quantiles
 import matplotlib.pyplot as plt
-import os 
-import numpy as np 
+import numpy as np
+import pytest
+
+from epydemix import load_predefined_model
+from epydemix.population import Population
+from epydemix.visualization import plot_contact_matrix, plot_population, plot_quantiles
+
 
 @pytest.fixture
-def mock_population(): 
+def mock_population():
     population = Population()
-    population.add_population(np.random.randint(0, 100000, size=5), 
-                              ["0-9", "10-19", "20-29", "30-39", "40+"])
-    population.add_contact_matrix(np.random.random(size=(5,5)), "school")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "work")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "home")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "community")
+    population.add_population(
+        np.random.randint(0, 100000, size=5), ["0-9", "10-19", "20-29", "30-39", "40+"]
+    )
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "school")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "work")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "home")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "community")
     return population
 
-def test_model_with_population(mock_population): 
-    
+
+def test_model_with_population(mock_population):
     fig, axes = plt.subplots(nrows=2, ncols=2, dpi=300)
-    plot_contact_matrix(mock_population, "school", ax=axes[0,0], fontsize=7, show_values=True)
-    plot_contact_matrix(mock_population, "work", ax=axes[0,1], fontsize=7, show_values=True)
-    plot_contact_matrix(mock_population, "home", ax=axes[1,0], fontsize=7, show_values=True)
-    plot_contact_matrix(mock_population, "community", ax=axes[1,1], fontsize=7, show_values=True)
+    plot_contact_matrix(
+        mock_population, "school", ax=axes[0, 0], fontsize=7, show_values=True
+    )
+    plot_contact_matrix(
+        mock_population, "work", ax=axes[0, 1], fontsize=7, show_values=True
+    )
+    plot_contact_matrix(
+        mock_population, "home", ax=axes[1, 0], fontsize=7, show_values=True
+    )
+    plot_contact_matrix(
+        mock_population, "community", ax=axes[1, 1], fontsize=7, show_values=True
+    )
     plt.tight_layout()
     plt.close()
 
     fig, axes = plt.subplots(ncols=2, dpi=300, figsize=(10, 5))
-    plot_population(mock_population, ax=axes[0], title="Population Distribution (absolute numbers)")
-    plot_population(mock_population, ax=axes[1], title="Population Distribution (percentages)", show_perc=True)
-    plt.close() 
+    plot_population(
+        mock_population, ax=axes[0], title="Population Distribution (absolute numbers)"
+    )
+    plot_population(
+        mock_population,
+        ax=axes[1],
+        title="Population Distribution (percentages)",
+        show_perc=True,
+    )
+    plt.close()
 
-    my_population = Population(name="My Population")    
+    my_population = Population(name="My Population")
     my_population.add_population(Nk=[100, 100], Nk_names=["A", "B"])
-    my_population.add_contact_matrix(contact_matrix=[[0.2, 0.3], [0.3, 0.2]], layer_name="all")
+    my_population.add_contact_matrix(
+        contact_matrix=[[0.2, 0.3], [0.3, 0.2]], layer_name="all"
+    )
 
     print(my_population)
 
     # create a simple SIR model
     model = load_predefined_model("SIR", transmission_rate=0.04)
 
-    # set the population (alternatively you can import it using model.import_epydemix_population('Kenya'))    
+    # set the population (alternatively you can import it using model.import_epydemix_population('Kenya'))
     model.set_population(mock_population)
 
     print(model)
 
-    # simulate 
-    results = model.run_simulations(start_date="2019-12-01", 
-                                    end_date="2020-04-01", 
-                                    percentage_in_agents=10 / model.population.Nk.sum(),
-                                    Nsim=5)
+    # simulate
+    results = model.run_simulations(
+        start_date="2019-12-01",
+        end_date="2020-04-01",
+        percentage_in_agents=10 / model.population.Nk.sum(),
+        Nsim=5,
+    )
 
     # plot results
     df_quantiles_comps = results.get_quantiles_compartments()
-    ax = plot_quantiles(df_quantiles_comps, columns=["Infected_total", "Susceptible_total", "Recovered_total"], legend_loc="center right")
-    ax = plot_quantiles(df_quantiles_comps, columns=["Infected_0-9", "Infected_10-19", "Infected_20-29", "Infected_30-39", "Infected_40+"], legend_loc="center right")
+    plot_quantiles(
+        df_quantiles_comps,
+        columns=["Infected_total", "Susceptible_total", "Recovered_total"],
+        legend_loc="center right",
+    )
+    plot_quantiles(
+        df_quantiles_comps,
+        columns=[
+            "Infected_0-9",
+            "Infected_10-19",
+            "Infected_20-29",
+            "Infected_30-39",
+            "Infected_40+",
+        ],
+        legend_loc="center right",
+    )
     plt.close()

--- a/tests/test_tutorial3.py
+++ b/tests/test_tutorial3.py
@@ -1,32 +1,37 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
-from epydemix import load_predefined_model
-from epydemix.visualization import plot_quantiles, plot_spectral_radius
-from epydemix.population import load_epydemix_population
-from epydemix.utils import compute_simulation_dates
 import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+
+from epydemix import load_predefined_model
 from epydemix.population import Population
-import numpy as np 
-import seaborn as sns   
+from epydemix.utils import compute_simulation_dates
+from epydemix.visualization import plot_quantiles, plot_spectral_radius
+
 colors = sns.color_palette("Dark2")
 
+
 @pytest.fixture
-def mock_population(): 
+def mock_population():
     population = Population()
-    population.add_population(np.random.randint(0, 100000, size=5), 
-                              ["0-9", "10-19", "20-29", "30-39", "40+"])
-    population.add_contact_matrix(np.random.random(size=(5,5)), "school")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "work")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "home")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "community")
+    population.add_population(
+        np.random.randint(0, 100000, size=5), ["0-9", "10-19", "20-29", "30-39", "40+"]
+    )
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "school")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "work")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "home")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "community")
     return population
 
-def test_modeling_interventions(mock_population): 
-    # import population and set simulation dates
+
+def test_modeling_interventions(mock_population):
+    # import population and set simulation dates
     simulation_dates = compute_simulation_dates("2024-01-01", "2024-08-31")
 
-    # create model with interventions and set population 
+    # create model with interventions and set population
     model_interventions = load_predefined_model("SIR", transmission_rate=0.035)
     model_interventions.set_population(mock_population)
 
@@ -35,35 +40,68 @@ def test_modeling_interventions(mock_population):
     model_nointerventions.set_population(mock_population)
 
     # Define the interventions by using a multplying factor
-    model_interventions.add_intervention(layer_name="work", start_date="2024-01-15", end_date="2024-02-15", reduction_factor=0.3, name="workplace closure")
-    model_interventions.add_intervention(layer_name="school", start_date="2024-03-01", end_date="2024-05-01", reduction_factor=0.35, name="school closure")
+    model_interventions.add_intervention(
+        layer_name="work",
+        start_date="2024-01-15",
+        end_date="2024-02-15",
+        reduction_factor=0.3,
+        name="workplace closure",
+    )
+    model_interventions.add_intervention(
+        layer_name="school",
+        start_date="2024-03-01",
+        end_date="2024-05-01",
+        reduction_factor=0.35,
+        name="school closure",
+    )
 
     # compute contact reductions (in order to plot them)
     model_interventions.compute_contact_reductions(simulation_dates)
 
-    # plot percentage change in spectral radius with respect to the initial value
+    # plot percentage change in spectral radius with respect to the initial value
     plot_spectral_radius(model_interventions, legend_loc="center right", show_perc=True)
     plt.close()
-    
-    model_interventions.override_parameter(start_date="2024-02-01", 
-                                       end_date="2024-08-31",
-                                       parameter_name="transmission_rate",
-                                       value=0.02)
-    
-    # simulate with 10 infected individuals
-    results_interventions = model_interventions.run_simulations(start_date="2024-01-01", end_date="2024-08-31", Nsim=5, 
-                                                                percentage_in_agents=10 / model_interventions.population.Nk.sum())
 
-    results_nointerventions = model_nointerventions.run_simulations(start_date="2024-01-01", end_date="2024-08-31", Nsim=5, 
-                                                                    percentage_in_agents=10 / model_nointerventions.population.Nk.sum())
+    model_interventions.override_parameter(
+        start_date="2024-02-01",
+        end_date="2024-08-31",
+        parameter_name="transmission_rate",
+        value=0.02,
+    )
+
+    # simulate with 10 infected individuals
+    results_interventions = model_interventions.run_simulations(
+        start_date="2024-01-01",
+        end_date="2024-08-31",
+        Nsim=5,
+        percentage_in_agents=10 / model_interventions.population.Nk.sum(),
+    )
+
+    results_nointerventions = model_nointerventions.run_simulations(
+        start_date="2024-01-01",
+        end_date="2024-08-31",
+        Nsim=5,
+        percentage_in_agents=10 / model_nointerventions.population.Nk.sum(),
+    )
 
     # plot results
     fig, ax = plt.subplots(1, 1, figsize=(10, 5), dpi=300)
 
     df_interventions = results_interventions.get_quantiles_compartments()
-    ax = plot_quantiles(df_interventions, columns=["Infected_total"], colors=colors[0], labels="I(t), Interventions", ax=ax)
+    ax = plot_quantiles(
+        df_interventions,
+        columns=["Infected_total"],
+        colors=colors[0],
+        labels="I(t), Interventions",
+        ax=ax,
+    )
 
     df_no_interventions = results_nointerventions.get_quantiles_compartments()
-    ax = plot_quantiles(df_no_interventions, columns=["Infected_total"], colors=colors[1], labels="I(t), No interventions", ax=ax) 
+    ax = plot_quantiles(
+        df_no_interventions,
+        columns=["Infected_total"],
+        colors=colors[1],
+        labels="I(t), No interventions",
+        ax=ax,
+    )
     plt.close()
-    

--- a/tests/test_tutorial4.py
+++ b/tests/test_tutorial4.py
@@ -1,35 +1,50 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
-from scipy import stats 
-import pandas as pd
+import matplotlib.pyplot as plt
 import numpy as np
-import matplotlib.pyplot as plt 
+import pandas as pd
+import seaborn as sns
+from scipy import stats
+
 from epydemix import load_predefined_model, simulate
-from epydemix.visualization import plot_distance_distribution, plot_quantiles, plot_posterior_distribution, plot_posterior_distribution_2d
-from epydemix.calibration import ABCSampler, rmse 
-from epydemix.utils import compute_simulation_dates
+from epydemix.calibration import ABCSampler, rmse
 from epydemix.population import Population
-import seaborn as sns   
+from epydemix.utils import compute_simulation_dates
+from epydemix.visualization import (
+    plot_distance_distribution,
+    plot_posterior_distribution,
+    plot_posterior_distribution_2d,
+    plot_quantiles,
+)
+
 colors = sns.color_palette("Dark2")
 
+
 @pytest.fixture
-def mock_population(): 
+def mock_population():
     population = Population()
-    population.add_population(np.random.randint(0, 100000, size=5), 
-                              ["0-9", "10-19", "20-29", "30-39", "40+"])
-    population.add_contact_matrix(np.random.random(size=(5,5)), "school")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "work")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "home")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "community")
+    population.add_population(
+        np.random.randint(0, 100000, size=5), ["0-9", "10-19", "20-29", "30-39", "40+"]
+    )
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "school")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "work")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "home")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "community")
     return population
 
-def test_calibration(mock_population): 
-    data = pd.read_csv("https://raw.githubusercontent.com/epistorm/epydemix/refs/heads/main/tutorials/data/incidence_data.csv")
+
+def test_calibration(mock_population):
+    data = pd.read_csv(
+        "https://raw.githubusercontent.com/epistorm/epydemix/refs/heads/main/tutorials/data/incidence_data.csv"
+    )
     data["date"] = pd.to_datetime(data["date"])
 
     fig, ax = plt.subplots(dpi=300, figsize=(10, 3))
-    plt.plot(data["date"], data["data"], label="I", color="k", linestyle="None", marker="o")
+    plt.plot(
+        data["date"], data["data"], label="I", color="k", linestyle="None", marker="o"
+    )
     plt.xlabel("Date")
     plt.ylabel("New Infections")
 
@@ -38,77 +53,219 @@ def test_calibration(mock_population):
     print(model)
 
     # initial conditions (we assume fully S population except for 0.05% infected individual across age groups)
-    initial_conditions = {"Susceptible": model.population.Nk - (model.population.Nk * 0.05 / 100).astype(int), 
-                        "Infected": (model.population.Nk * 0.05/100).astype(int),
-                        "Recovered": np.zeros(len(model.population.Nk))}
+    initial_conditions = {
+        "Susceptible": model.population.Nk
+        - (model.population.Nk * 0.05 / 100).astype(int),
+        "Infected": (model.population.Nk * 0.05 / 100).astype(int),
+        "Recovered": np.zeros(len(model.population.Nk)),
+    }
 
-    # simulation dates 
-    simulation_dates = compute_simulation_dates(start_date=data.date.values[0], end_date=data.date.values[-1])
+    # simulation dates
+    simulation_dates = compute_simulation_dates(
+        start_date=data.date.values[0], end_date=data.date.values[-1]
+    )
 
     # simulation parameters
-    parameters = {"initial_conditions_dict": initial_conditions,
-                "epimodel": model, 
-                "start_date": data.date.values[0],
-                "end_date": data.date.values[-1]
-                }
-    
-    priors = {"transmission_rate": stats.uniform(0.010, 0.020), 
-          "recovery_rate": stats.uniform(0.15, 0.1)}
-    
-    def simulate_wrapper(parameters): 
+    parameters = {
+        "initial_conditions_dict": initial_conditions,
+        "epimodel": model,
+        "start_date": data.date.values[0],
+        "end_date": data.date.values[-1],
+    }
+
+    priors = {
+        "transmission_rate": stats.uniform(0.010, 0.020),
+        "recovery_rate": stats.uniform(0.15, 0.1),
+    }
+
+    def simulate_wrapper(parameters):
         results = simulate(**parameters)
         return {"data": results.transitions["Susceptible_to_Infected_total"]}
 
-    # initialize the ABCSampler object
-    abc_sampler = ABCSampler(simulation_function=simulate_wrapper, 
-                            priors=priors, 
-                            parameters=parameters, 
-                            observed_data=data["data"].values, 
-                            distance_function=rmse)
-    
-    results_abc_smc = abc_sampler.calibrate(strategy="smc", 
-                    num_particles=5, 
-                    num_generations=2)
-    
-    results_abc_rejection = abc_sampler.calibrate(strategy="rejection", 
-                                  num_particles=5, 
-                                  epsilon=5500000000)
-    
-    results_top_perc = abc_sampler.calibrate(strategy="top_fraction", 
-                                         Nsim=20,
-                                         top_fraction=0.1)
-    
-    # compute quantiles 
-    df_quantiles_abc_smc = results_abc_smc.get_calibration_quantiles(dates=simulation_dates)
-    df_quantiles_abc_rejection = results_abc_rejection.get_calibration_quantiles(dates=simulation_dates)
-    df_quantiles_top_perc = results_top_perc.get_calibration_quantiles(dates=simulation_dates)
+    # initialize the ABCSampler object
+    abc_sampler = ABCSampler(
+        simulation_function=simulate_wrapper,
+        priors=priors,
+        parameters=parameters,
+        observed_data=data["data"].values,
+        distance_function=rmse,
+    )
+
+    results_abc_smc = abc_sampler.calibrate(
+        strategy="smc", num_particles=5, num_generations=2
+    )
+
+    results_abc_rejection = abc_sampler.calibrate(
+        strategy="rejection", num_particles=5, epsilon=5500000000
+    )
+
+    results_top_perc = abc_sampler.calibrate(
+        strategy="top_fraction", Nsim=20, top_fraction=0.1
+    )
+
+    # compute quantiles
+    df_quantiles_abc_smc = results_abc_smc.get_calibration_quantiles(
+        dates=simulation_dates
+    )
+    df_quantiles_abc_rejection = results_abc_rejection.get_calibration_quantiles(
+        dates=simulation_dates
+    )
+    df_quantiles_top_perc = results_top_perc.get_calibration_quantiles(
+        dates=simulation_dates
+    )
 
     fig, axes = plt.subplots(3, 1, figsize=(10, 6), dpi=300)
-    plot_quantiles(df_quantiles_abc_smc, columns="data", data=data, ax=axes[0], title="ABC-SMC", colors=colors[0], show_data=True, labels=["New Infections"])   
-    plot_quantiles(df_quantiles_abc_rejection, columns="data", data=data, ax=axes[1], show_legend=False, title="ABC Rejection", colors=colors[1], show_data=True)
-    plot_quantiles(df_quantiles_top_perc, columns="data", data=data, ax=axes[2], show_legend=False, title="Top X%", colors=colors[2], show_data=True)
+    plot_quantiles(
+        df_quantiles_abc_smc,
+        columns="data",
+        data=data,
+        ax=axes[0],
+        title="ABC-SMC",
+        colors=colors[0],
+        show_data=True,
+        labels=["New Infections"],
+    )
+    plot_quantiles(
+        df_quantiles_abc_rejection,
+        columns="data",
+        data=data,
+        ax=axes[1],
+        show_legend=False,
+        title="ABC Rejection",
+        colors=colors[1],
+        show_data=True,
+    )
+    plot_quantiles(
+        df_quantiles_top_perc,
+        columns="data",
+        data=data,
+        ax=axes[2],
+        show_legend=False,
+        title="Top X%",
+        colors=colors[2],
+        show_data=True,
+    )
     plt.tight_layout()
 
-    fig, axes = plt.subplots(1, 3, figsize=(10, 3), dpi=300, sharex=True, sharey=True)  
+    fig, axes = plt.subplots(1, 3, figsize=(10, 3), dpi=300, sharex=True, sharey=True)
 
-    plot_posterior_distribution_2d(results_abc_smc.get_posterior_distribution(), "transmission_rate", "recovery_rate", ax=axes[0], kind="kde", title="ABC-SMC", prior_range=False)
-    plot_posterior_distribution_2d(results_abc_rejection.get_posterior_distribution(), "transmission_rate", "recovery_rate", ax=axes[1], kind="kde", title="ABC Rejection", prior_range=False)
-    plot_posterior_distribution_2d(results_top_perc.get_posterior_distribution(), "transmission_rate", "recovery_rate", ax=axes[2], kind="kde", title="Top X%", prior_range=False)
+    plot_posterior_distribution_2d(
+        results_abc_smc.get_posterior_distribution(),
+        "transmission_rate",
+        "recovery_rate",
+        ax=axes[0],
+        kind="kde",
+        title="ABC-SMC",
+        prior_range=False,
+    )
+    plot_posterior_distribution_2d(
+        results_abc_rejection.get_posterior_distribution(),
+        "transmission_rate",
+        "recovery_rate",
+        ax=axes[1],
+        kind="kde",
+        title="ABC Rejection",
+        prior_range=False,
+    )
+    plot_posterior_distribution_2d(
+        results_top_perc.get_posterior_distribution(),
+        "transmission_rate",
+        "recovery_rate",
+        ax=axes[2],
+        kind="kde",
+        title="Top X%",
+        prior_range=False,
+    )
     plt.tight_layout()
 
     fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(10, 3), dpi=300)
-    plot_posterior_distribution(results_abc_smc.get_posterior_distribution(), "transmission_rate", ax=axes[0], kind="kde", title="Transmission rate", prior_range=False, color=colors[0], label="ABC-SMC")
-    plot_posterior_distribution(results_abc_rejection.get_posterior_distribution(), "transmission_rate", ax=axes[0], kind="kde", title="Transmission rate", prior_range=False, color=colors[1], label="ABC Rejection")
-    plot_posterior_distribution(results_top_perc.get_posterior_distribution(), "transmission_rate", ax=axes[0], kind="kde", title="Transmission rate", prior_range=False, color=colors[2], label="Top X%")
-    axes[0].legend()    
+    plot_posterior_distribution(
+        results_abc_smc.get_posterior_distribution(),
+        "transmission_rate",
+        ax=axes[0],
+        kind="kde",
+        title="Transmission rate",
+        prior_range=False,
+        color=colors[0],
+        label="ABC-SMC",
+    )
+    plot_posterior_distribution(
+        results_abc_rejection.get_posterior_distribution(),
+        "transmission_rate",
+        ax=axes[0],
+        kind="kde",
+        title="Transmission rate",
+        prior_range=False,
+        color=colors[1],
+        label="ABC Rejection",
+    )
+    plot_posterior_distribution(
+        results_top_perc.get_posterior_distribution(),
+        "transmission_rate",
+        ax=axes[0],
+        kind="kde",
+        title="Transmission rate",
+        prior_range=False,
+        color=colors[2],
+        label="Top X%",
+    )
+    axes[0].legend()
 
-    plot_posterior_distribution(results_abc_smc.get_posterior_distribution(), "recovery_rate", ax=axes[1], kind="kde", title="Recovery rate", prior_range=False, color=colors[0], label="ABC-SMC")
-    plot_posterior_distribution(results_abc_rejection.get_posterior_distribution(), "recovery_rate", ax=axes[1], kind="kde", title="Recovery rate", prior_range=False, color=colors[1], label="ABC Rejection")
-    plot_posterior_distribution(results_top_perc.get_posterior_distribution(), "recovery_rate", ax=axes[1], kind="kde", title="Recovery rate", prior_range=False, color=colors[2], label="Top X%")
+    plot_posterior_distribution(
+        results_abc_smc.get_posterior_distribution(),
+        "recovery_rate",
+        ax=axes[1],
+        kind="kde",
+        title="Recovery rate",
+        prior_range=False,
+        color=colors[0],
+        label="ABC-SMC",
+    )
+    plot_posterior_distribution(
+        results_abc_rejection.get_posterior_distribution(),
+        "recovery_rate",
+        ax=axes[1],
+        kind="kde",
+        title="Recovery rate",
+        prior_range=False,
+        color=colors[1],
+        label="ABC Rejection",
+    )
+    plot_posterior_distribution(
+        results_top_perc.get_posterior_distribution(),
+        "recovery_rate",
+        ax=axes[1],
+        kind="kde",
+        title="Recovery rate",
+        prior_range=False,
+        color=colors[2],
+        label="Top X%",
+    )
     axes[1].legend()
 
     fig, ax = plt.subplots(figsize=(10, 5), dpi=300)
-    plot_distance_distribution(results_abc_smc.get_distances(), ax=ax, kind="kde", color=colors[0], label="ABC-SMC", xlabel="RMSE")
-    plot_distance_distribution(results_abc_rejection.get_distances(), ax=ax, kind="kde", color=colors[1], label="ABC Rejection", xlabel="RMSE")
-    plot_distance_distribution(results_top_perc.get_distances(), ax=ax, kind="kde", color=colors[2], label="Top X%", xlabel="RMSE")
+    plot_distance_distribution(
+        results_abc_smc.get_distances(),
+        ax=ax,
+        kind="kde",
+        color=colors[0],
+        label="ABC-SMC",
+        xlabel="RMSE",
+    )
+    plot_distance_distribution(
+        results_abc_rejection.get_distances(),
+        ax=ax,
+        kind="kde",
+        color=colors[1],
+        label="ABC Rejection",
+        xlabel="RMSE",
+    )
+    plot_distance_distribution(
+        results_top_perc.get_distances(),
+        ax=ax,
+        kind="kde",
+        color=colors[2],
+        label="Top X%",
+        xlabel="RMSE",
+    )
     ax.legend()

--- a/tests/test_tutorial5.py
+++ b/tests/test_tutorial5.py
@@ -1,75 +1,95 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
-from scipy import stats 
-import pandas as pd
+import matplotlib.pyplot as plt
 import numpy as np
-import matplotlib.pyplot as plt 
+import pandas as pd
+import seaborn as sns
+from scipy import stats
+
 from epydemix import load_predefined_model, simulate
-from epydemix.visualization import plot_posterior_distribution
 from epydemix.calibration import ABCSampler
-from epydemix.utils import compute_simulation_dates
-from epydemix.visualization import plot_quantiles, plot_posterior_distribution_2d
 from epydemix.population import Population
-from epydemix.utils import Perturbation
-import seaborn as sns   
+from epydemix.utils import Perturbation, compute_simulation_dates
+from epydemix.visualization import (
+    plot_posterior_distribution,
+    plot_quantiles,
+)
+
 colors = sns.color_palette("Dark2")
 
+
 @pytest.fixture
-def mock_population(): 
+def mock_population():
     population = Population()
-    population.add_population(np.random.randint(0, 100000, size=5), 
-                              ["0-9", "10-19", "20-29", "30-39", "40+"])
-    population.add_contact_matrix(np.random.random(size=(5,5)), "school")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "work")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "home")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "community")
+    population.add_population(
+        np.random.randint(0, 100000, size=5), ["0-9", "10-19", "20-29", "30-39", "40+"]
+    )
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "school")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "work")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "home")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "community")
     return population
 
 
 def test_calibration_advanced(mock_population):
     # import data and divide data into calibration and projection periods
-    data = pd.read_csv('https://raw.githubusercontent.com/epistorm/epydemix/refs/heads/main/tutorials/data/incidence_data.csv')
+    data = pd.read_csv(
+        "https://raw.githubusercontent.com/epistorm/epydemix/refs/heads/main/tutorials/data/incidence_data.csv"
+    )
     data["date"] = pd.to_datetime(data["date"])
     data_calibration = data.iloc[:-40]
     data_projection = data.iloc[-40:]
 
-    # model 
+    # model
     model = load_predefined_model("SIR")
     model.set_population(mock_population)
 
     # initial conditions (we assume fully S population except for 0.05% infected individual across age groups)
-    initial_conditions = {"Susceptible": model.population.Nk - (model.population.Nk * 0.05 / 100).astype(int), 
-                        "Infected": (model.population.Nk * 0.05/100).astype(int),
-                        "Recovered": np.zeros(len(model.population.Nk))}
+    initial_conditions = {
+        "Susceptible": model.population.Nk
+        - (model.population.Nk * 0.05 / 100).astype(int),
+        "Infected": (model.population.Nk * 0.05 / 100).astype(int),
+        "Recovered": np.zeros(len(model.population.Nk)),
+    }
 
-    # simulation dates 
-    simulation_dates_calibration = compute_simulation_dates(start_date=data_calibration.date.values[0], 
-                                                            end_date=data_calibration.date.values[-1])
-    simulation_dates_projection = compute_simulation_dates(start_date=data_calibration.date.values[0], 
-                                                            end_date=data_projection.date.values[-1])
+    # simulation dates
+    simulation_dates_calibration = compute_simulation_dates(
+        start_date=data_calibration.date.values[0],
+        end_date=data_calibration.date.values[-1],
+    )
+    simulation_dates_projection = compute_simulation_dates(
+        start_date=data_calibration.date.values[0],
+        end_date=data_projection.date.values[-1],
+    )
 
     # simulation parameters
-    parameters = {"initial_conditions_dict": initial_conditions,
-                "epimodel": model, 
-                "start_date": data_calibration.date.values[0],
-                "end_date": data_calibration.date.values[-1]}
+    parameters = {
+        "initial_conditions_dict": initial_conditions,
+        "epimodel": model,
+        "start_date": data_calibration.date.values[0],
+        "end_date": data_calibration.date.values[-1],
+    }
 
-    # priors
-    priors = {"transmission_rate": stats.uniform(0.010, 0.020), 
-            "recovery_rate": stats.uniform(0.15, 0.1)}
+    # priors
+    priors = {
+        "transmission_rate": stats.uniform(0.010, 0.020),
+        "recovery_rate": stats.uniform(0.15, 0.1),
+    }
 
     # wrapper function
-    def simulate_wrapper(parameters): 
+    def simulate_wrapper(parameters):
         results = simulate(**parameters)
         return {"data": results.transitions["Susceptible_to_Infected_total"]}
 
-    # initialize the ABCSampler object
-    abc_sampler = ABCSampler(simulation_function=simulate_wrapper, 
-                            priors=priors, 
-                            parameters=parameters, 
-                            observed_data=data_calibration["data"].values)
-
+    # initialize the ABCSampler object
+    abc_sampler = ABCSampler(
+        simulation_function=simulate_wrapper,
+        priors=priors,
+        parameters=parameters,
+        observed_data=data_calibration["data"].values,
+    )
 
     class UniformPerturbation(Perturbation):
         def __init__(self, param_name, scale=0.1):
@@ -90,20 +110,37 @@ def test_calibration_advanced(mock_population):
             values = particles[:, index]
             self.scale = 0.5 * (np.max(values) - np.min(values))
 
-    results_uniform = abc_sampler.calibrate(strategy="smc", 
-                        num_particles=10, 
-                        num_generations=2,
-                        perturbations={
-                            "transmission_rate": UniformPerturbation("transmission_rate"), 
-                            "recovery_rate": UniformPerturbation("recovery_rate")
-                        })
+    results_uniform = abc_sampler.calibrate(
+        strategy="smc",
+        num_particles=10,
+        num_generations=2,
+        perturbations={
+            "transmission_rate": UniformPerturbation("transmission_rate"),
+            "recovery_rate": UniformPerturbation("recovery_rate"),
+        },
+    )
 
-    results_abc_smc = abc_sampler.calibrate(strategy="smc", 
-                        num_particles=10, 
-                        num_generations=2)
+    results_abc_smc = abc_sampler.calibrate(
+        strategy="smc", num_particles=10, num_generations=2
+    )
 
-    ax = plot_posterior_distribution(results_uniform.get_posterior_distribution(), "transmission_rate", kind="kde", title="Transmission rate", color=colors[0], label="Uniform Perturbation")
-    ax = plot_posterior_distribution(results_abc_smc.get_posterior_distribution(), "transmission_rate", kind="kde", title="Transmission rate", color=colors[1], label="Default Perturbation", ax=ax)
+    ax = plot_posterior_distribution(
+        results_uniform.get_posterior_distribution(),
+        "transmission_rate",
+        kind="kde",
+        title="Transmission rate",
+        color=colors[0],
+        label="Uniform Perturbation",
+    )
+    ax = plot_posterior_distribution(
+        results_abc_smc.get_posterior_distribution(),
+        "transmission_rate",
+        kind="kde",
+        title="Transmission rate",
+        color=colors[1],
+        label="Default Perturbation",
+        ax=ax,
+    )
     ax.legend()
 
     # create projection parameters
@@ -113,10 +150,31 @@ def test_calibration_advanced(mock_population):
     # run projections
     results_abc_smc = abc_sampler.run_projections(projection_parameters, iterations=5)
 
-    # plot the projections
-    df_quantiles_calibration = results_abc_smc.get_calibration_quantiles(simulation_dates_calibration)
-    df_quantiles_projections = results_abc_smc.get_projection_quantiles(simulation_dates_projection)
+    # plot the projections
+    df_quantiles_calibration = results_abc_smc.get_calibration_quantiles(
+        simulation_dates_calibration
+    )
+    df_quantiles_projections = results_abc_smc.get_projection_quantiles(
+        simulation_dates_projection
+    )
 
     fig, ax = plt.subplots(dpi=300, figsize=(10, 3))
-    plot_quantiles(df_quantiles_projections, columns="data", data=data, ax=ax, colors=colors[0], show_legend=True, show_data=True, labels=["New Infections, Projections"])
-    plot_quantiles(df_quantiles_calibration, columns="data", data=data_calibration, ax=ax, colors=colors[1], show_legend=False, show_data=True);
+    plot_quantiles(
+        df_quantiles_projections,
+        columns="data",
+        data=data,
+        ax=ax,
+        colors=colors[0],
+        show_legend=True,
+        show_data=True,
+        labels=["New Infections, Projections"],
+    )
+    plot_quantiles(
+        df_quantiles_calibration,
+        columns="data",
+        data=data_calibration,
+        ax=ax,
+        colors=colors[1],
+        show_legend=False,
+        show_data=True,
+    )

--- a/tests/test_tutorial6.py
+++ b/tests/test_tutorial6.py
@@ -1,99 +1,115 @@
-import pytest
 import matplotlib
+import pytest
+
 matplotlib.use("Agg")  # Use non-GUI backend before importing pyplot
-from epydemix import EpiModel, load_predefined_model
 import matplotlib.pyplot as plt
-from epydemix.visualization import plot_quantiles
 import numpy as np
-from epydemix.utils import convert_to_2Darray, compute_simulation_dates
+
+from epydemix import EpiModel, load_predefined_model
 from epydemix.population import Population
+from epydemix.utils import compute_simulation_dates, convert_to_2Darray
+from epydemix.visualization import plot_quantiles
 
 
 @pytest.fixture
-def mock_population(): 
+def mock_population():
     population = Population()
-    population.add_population(np.random.randint(0, 100000, size=5), 
-                              ["0-9", "10-19", "20-29", "30-39", "40+"])
-    population.add_contact_matrix(np.random.random(size=(5,5)), "school")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "work")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "home")
-    population.add_contact_matrix(np.random.random(size=(5,5)), "community")
+    population.add_population(
+        np.random.randint(0, 100000, size=5), ["0-9", "10-19", "20-29", "30-39", "40+"]
+    )
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "school")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "work")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "home")
+    population.add_contact_matrix(np.random.random(size=(5, 5)), "community")
     return population
 
+
 def test_new_transitions():
-    def compute_behavioral_transition_probability(params, data): 
+    def compute_behavioral_transition_probability(params, data):
         """
         Compute the probability of a behavioral transition.
 
         Args:
             params: The parameters of the transition.
             data: A dictionary containing information about the current state of the system.
-                - parameters: The model parameters. This is a dictionary of arrays, where the key is the name of the parameter and the value is a 
+                - parameters: The model parameters. This is a dictionary of arrays, where the key is the name of the parameter and the value is a
                             2D array of shape (n_time_steps, n_groups). The first dimension is the time step, the second is the demographic group.
                 - t: The current time step
-                - comp_indices: The indices of the compartments. This is a dictionary where the key is the name of the compartment and the 
+                - comp_indices: The indices of the compartments. This is a dictionary where the key is the name of the compartment and the
                                 value is the index of the compartment in the system.
                 - contact_matrix: The contact matrix
-                - pop: The population in different compartments. This is a 2D array of shape (n_compartments, n_groups). The first dimension is 
+                - pop: The population in different compartments. This is a 2D array of shape (n_compartments, n_groups). The first dimension is
                     the compartment, the second is the demographic group.
                 - pop_sizes: The population sizes. This is a 1D array of shape (n_groups,).
                 - dt: The time step size
         """
-        beta_B, gamma = data["parameters"][params[0]][data["t"]], data["parameters"][params[1]][data["t"]]
+        beta_B, gamma = (
+            data["parameters"][params[0]][data["t"]],
+            data["parameters"][params[1]][data["t"]],
+        )
         agent_idx = data["comp_indices"][params[2]]
         interaction = beta_B * (1 - np.exp(-gamma * np.sum(data["pop"][agent_idx])))
         return 1 - np.exp(-interaction * data["dt"])
 
+    model = EpiModel(
+        compartments=["S", "SB", "I", "R"],
+        parameters={
+            "beta": 0.3,
+            "mu": 0.1,
+            "r": 0.3,
+            "beta_B": 0.05,
+            "gamma": 1.0 / 10000.0,
+        },
+    )
 
-    model = EpiModel(compartments=["S", "SB", "I", "R"], 
-                    parameters={"beta": 0.3, 
-                                "mu": 0.1, 
-                                "r": 0.3,
-                                "beta_B": 0.05, 
-                                "gamma": 1. / 10000.})
-
-    model.register_transition_kind(kind="behavioral", function=compute_behavioral_transition_probability)
+    model.register_transition_kind(
+        kind="behavioral", function=compute_behavioral_transition_probability
+    )
 
     model.add_transition(source="S", target="I", params=("beta", "I"), kind="mediated")
-    model.add_transition(source="SB", target="I", params=("r*beta", "I"), kind="mediated")
-    model.add_transition(source="S", target="SB", params=("beta_B", "gamma", "I"), kind="behavioral")
+    model.add_transition(
+        source="SB", target="I", params=("r*beta", "I"), kind="mediated"
+    )
+    model.add_transition(
+        source="S", target="SB", params=("beta_B", "gamma", "I"), kind="behavioral"
+    )
     model.add_transition(source="I", target="R", params="mu", kind="spontaneous")
 
     # Initial conditions
-    initial_conditions = {
-        'S': 100000-10,  
-        'SB': 0,   
-        'I': 10,   
-        'R': 0     
-    }
+    initial_conditions = {"S": 100000 - 10, "SB": 0, "I": 10, "R": 0}
 
     # running the simulations
     results = model.run_simulations(
         start_date="2024-01-01",
         end_date="2024-04-10",
-        initial_conditions_dict=initial_conditions, 
-        Nsim=5
+        initial_conditions_dict=initial_conditions,
+        Nsim=5,
     )
 
-    # plot
+    # plot
     df_quantiles = results.get_quantiles_compartments()
-    plot_quantiles(df_quantiles, columns=["S_total", "SB_total", "I_total", "R_total"], legend_loc="upper right");
+    plot_quantiles(
+        df_quantiles,
+        columns=["S_total", "SB_total", "I_total", "R_total"],
+        legend_loc="upper right",
+    )
     plt.close()
+
 
 def test_varying_params(mock_population):
     start_date, end_date = "2024-01-01", "2024-04-10"
-
 
     # define SIR model
     model = load_predefined_model("SIR")
 
     # get simulation dates
-    simulation_dates = compute_simulation_dates(start_date=start_date, end_date=end_date)
+    simulation_dates = compute_simulation_dates(
+        start_date=start_date, end_date=end_date
+    )
 
-    def create_seasonal_parameter(n_points: int, 
-                                min_val: float, 
-                                max_val: float, 
-                                period: int) -> np.ndarray:
+    def create_seasonal_parameter(
+        n_points: int, min_val: float, max_val: float, period: int
+    ) -> np.ndarray:
         """
         Create a sinusoidal parameter with specified inputs.
         """
@@ -103,20 +119,27 @@ def test_varying_params(mock_population):
         frequency = 2 * np.pi / period
         return amplitude * np.sin(frequency * t) + offset
 
-
-    time_varying_transmission_rate = create_seasonal_parameter(len(simulation_dates), 0.15, 0.35, 14)
+    time_varying_transmission_rate = create_seasonal_parameter(
+        len(simulation_dates), 0.15, 0.35, 14
+    )
     plt.plot(time_varying_transmission_rate)
     plt.close()
 
-    # add time-varying transmission rate to the model
-    model.add_parameter(parameter_name="transmission_rate", value=time_varying_transmission_rate)
+    # add time-varying transmission rate to the model
+    model.add_parameter(
+        parameter_name="transmission_rate", value=time_varying_transmission_rate
+    )
 
     # run simulations
     results = model.run_simulations(start_date=start_date, end_date=end_date, Nsim=5)
 
     # plot results
     df_quantiles = results.get_quantiles_compartments()
-    plot_quantiles(df_quantiles, columns=["Susceptible_total", "Infected_total", "Recovered_total"], legend_loc="upper right");
+    plot_quantiles(
+        df_quantiles,
+        columns=["Susceptible_total", "Infected_total", "Recovered_total"],
+        legend_loc="upper right",
+    )
     plt.close()
     # create model and add population
     model = load_predefined_model("SIR")
@@ -128,52 +151,103 @@ def test_varying_params(mock_population):
     age_varying_transmission_rate = convert_to_2Darray([0.01, 0.02, 0.02, 0.02, 0.02])
 
     # add age-varying transmission rate to the model
-    model.add_parameter(parameter_name="transmission_rate", value=age_varying_transmission_rate)
+    model.add_parameter(
+        parameter_name="transmission_rate", value=age_varying_transmission_rate
+    )
 
     # run simulations
     results = model.run_simulations(start_date=start_date, end_date=end_date, Nsim=5)
 
     # plot results
     df_quantiles = results.get_quantiles_compartments()
-    plot_quantiles(df_quantiles, columns=["Infected_0-9", "Infected_10-19", "Infected_20-29", "Infected_30-39", "Infected_40+"], legend_loc="upper right");
+    plot_quantiles(
+        df_quantiles,
+        columns=[
+            "Infected_0-9",
+            "Infected_10-19",
+            "Infected_20-29",
+            "Infected_30-39",
+            "Infected_40+",
+        ],
+        legend_loc="upper right",
+    )
     plt.close()
 
     varying_transmission_rate = np.zeros((len(simulation_dates), 5))
     for i in range(5):
         if i == 0:
-            varying_transmission_rate[:, i] = create_seasonal_parameter(len(simulation_dates), 0.01, 0.02, 14)
+            varying_transmission_rate[:, i] = create_seasonal_parameter(
+                len(simulation_dates), 0.01, 0.02, 14
+            )
         else:
-            varying_transmission_rate[:, i] = create_seasonal_parameter(len(simulation_dates), 0.015, 0.025, 14) 
+            varying_transmission_rate[:, i] = create_seasonal_parameter(
+                len(simulation_dates), 0.015, 0.025, 14
+            )
 
     # add time-varying and age-varying transmission rate to the model
-    model.add_parameter(parameter_name="transmission_rate", value=varying_transmission_rate)
+    model.add_parameter(
+        parameter_name="transmission_rate", value=varying_transmission_rate
+    )
 
     # run simulations
     results = model.run_simulations(start_date=start_date, end_date=end_date, Nsim=5)
 
     # plot results
     df_quantiles = results.get_quantiles_compartments()
-    plot_quantiles(df_quantiles, columns=["Infected_0-9", "Infected_10-19", "Infected_20-29", "Infected_30-39", "Infected_40+"], legend_loc="upper right");
+    plot_quantiles(
+        df_quantiles,
+        columns=[
+            "Infected_0-9",
+            "Infected_10-19",
+            "Infected_20-29",
+            "Infected_30-39",
+            "Infected_40+",
+        ],
+        legend_loc="upper right",
+    )
     plt.close()
+
 
 def test_shorter_dt():
     start_date, end_date = "2024-01-01", "2024-04-10"
     model = load_predefined_model("SIR")
 
     # run the models with 1/3 day time steps (by default, the data is resampled at daily frequency)
-    results_shorter_dt = model.run_simulations(start_date=start_date, end_date=end_date, dt=1/3, Nsim=5)
+    results_shorter_dt = model.run_simulations(
+        start_date=start_date, end_date=end_date, dt=1 / 3, Nsim=5
+    )
 
     # run the models with 1 day time steps and 1 week resampling frequency
-    results_resampled = model.run_simulations(start_date=start_date, end_date=end_date, dt=1, resample_frequency="W", Nsim=5)
+    results_resampled = model.run_simulations(
+        start_date=start_date, end_date=end_date, dt=1, resample_frequency="W", Nsim=5
+    )
 
     # plot results
-    plot_quantiles(results_shorter_dt.get_quantiles_compartments(), columns=["Susceptible_total", "Infected_total", "Recovered_total"], legend_loc="upper right");
-    plot_quantiles(results_resampled.get_quantiles_compartments(), columns=["Susceptible_total", "Infected_total", "Recovered_total"], legend_loc="upper right");
+    plot_quantiles(
+        results_shorter_dt.get_quantiles_compartments(),
+        columns=["Susceptible_total", "Infected_total", "Recovered_total"],
+        legend_loc="upper right",
+    )
+    plot_quantiles(
+        results_resampled.get_quantiles_compartments(),
+        columns=["Susceptible_total", "Infected_total", "Recovered_total"],
+        legend_loc="upper right",
+    )
     plt.close()
     # plot total weekly new infections
-    plot_quantiles(results_resampled.get_quantiles_transitions(), columns=["Susceptible_to_Infected_total"], legend_loc="upper right");
+    plot_quantiles(
+        results_resampled.get_quantiles_transitions(),
+        columns=["Susceptible_to_Infected_total"],
+        legend_loc="upper right",
+    )
     plt.close()
     # run the models with 1 day time steps but resample hourly
-    results_resampled = model.run_simulations(start_date=start_date, end_date=end_date, dt=1, resample_frequency="1h", Nsim=5)
-    plot_quantiles(results_resampled.get_quantiles_compartments(), columns=["Susceptible_total", "Infected_total", "Recovered_total"], legend_loc="center right");  
+    results_resampled = model.run_simulations(
+        start_date=start_date, end_date=end_date, dt=1, resample_frequency="1h", Nsim=5
+    )
+    plot_quantiles(
+        results_resampled.get_quantiles_compartments(),
+        columns=["Susceptible_total", "Infected_total", "Recovered_total"],
+        legend_loc="center right",
+    )
     plt.close()

--- a/validation/models/stochastic_seir.py
+++ b/validation/models/stochastic_seir.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 class StochasticSEIR:
     def __init__(self, S0, E0, I0, R0, beta, sigma, gamma, population, time_steps):
@@ -41,13 +42,13 @@ class StochasticSEIR:
         I = self.I0
         R = self.R0
 
-        results = {'S': [], 'E': [], 'I': [], 'R': []}
+        results = {"S": [], "E": [], "I": [], "R": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S)
-            results['E'].append(E)
-            results['I'].append(I)
-            results['R'].append(R)
+            results["S"].append(S)
+            results["E"].append(E)
+            results["I"].append(I)
+            results["R"].append(R)
 
             if I == 0 and E == 0:  # Stop if no more infected or exposed individuals
                 break
@@ -91,10 +92,10 @@ class StochasticSEIR:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(results['S'])
-            all_E.append(results['E'])
-            all_I.append(results['I'])
-            all_R.append(results['R'])
+            all_S.append(results["S"])
+            all_E.append(results["E"])
+            all_I.append(results["I"])
+            all_R.append(results["R"])
 
         # Find the longest simulation
         max_len = max(len(traj) for traj in all_S)
@@ -115,10 +116,10 @@ class StochasticSEIR:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'E': {q: np.quantile(all_E, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles},
-            'R': {q: np.quantile(all_R, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "E": {q: np.quantile(all_E, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
+            "R": {q: np.quantile(all_R, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
@@ -132,18 +133,28 @@ class StochasticSEIR:
                                              and inner keys as the quantiles (e.g., 0.25, 0.5, 0.75).
             quantiles (list of float): The quantiles to plot (e.g., [0.25, 0.5, 0.75]).
         """
-        time_range = range(len(quantile_results['S'][quantiles[0]]))
-        
+        time_range = range(len(quantile_results["S"][quantiles[0]]))
+
         for q in quantiles:
-            plt.plot(time_range, quantile_results['S'][q], label=f'Susceptible ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['E'][q], label=f'Exposed ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['I'][q], label=f'Infected ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['R'][q], label=f'Recovered ({q*100:.0f}%)')
+            plt.plot(
+                time_range,
+                quantile_results["S"][q],
+                label=f"Susceptible ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range, quantile_results["E"][q], label=f"Exposed ({q * 100:.0f}%)"
+            )
+            plt.plot(
+                time_range, quantile_results["I"][q], label=f"Infected ({q * 100:.0f}%)"
+            )
+            plt.plot(
+                time_range,
+                quantile_results["R"][q],
+                label=f"Recovered ({q * 100:.0f}%)",
+            )
 
-        plt.xlabel('Time Steps')
-        plt.ylabel('Population')
+        plt.xlabel("Time Steps")
+        plt.ylabel("Population")
         plt.legend()
-        plt.title('Stochastic SEIR Model - Quantiles over Multiple Simulations')
+        plt.title("Stochastic SEIR Model - Quantiles over Multiple Simulations")
         plt.show()
-
-

--- a/validation/models/stochastic_seir_population.py
+++ b/validation/models/stochastic_seir_population.py
@@ -1,8 +1,10 @@
 import numpy as np
-import matplotlib.pyplot as plt
+
 
 class StochasticSEIRAgeGroups:
-    def __init__(self, S0, E0, I0, R0, beta, sigma, gamma, contact_matrix, population, time_steps):
+    def __init__(
+        self, S0, E0, I0, R0, beta, sigma, gamma, contact_matrix, population, time_steps
+    ):
         """
         Initializes the stochastic SEIR model with age groups and a contact matrix.
 
@@ -44,15 +46,17 @@ class StochasticSEIRAgeGroups:
         I = self.I0.copy()
         R = self.R0.copy()
 
-        results = {'S': [], 'E': [], 'I': [], 'R': []}
+        results = {"S": [], "E": [], "I": [], "R": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S.copy())
-            results['E'].append(E.copy())
-            results['I'].append(I.copy())
-            results['R'].append(R.copy())
+            results["S"].append(S.copy())
+            results["E"].append(E.copy())
+            results["I"].append(I.copy())
+            results["R"].append(R.copy())
 
-            if np.sum(I) == 0 and np.sum(E) == 0:  # Stop if no more infected or exposed individuals
+            if (
+                np.sum(I) == 0 and np.sum(E) == 0
+            ):  # Stop if no more infected or exposed individuals
                 break
 
             # Compute new exposures for each age group
@@ -96,10 +100,10 @@ class StochasticSEIRAgeGroups:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(np.array(results['S']))
-            all_E.append(np.array(results['E']))
-            all_I.append(np.array(results['I']))
-            all_R.append(np.array(results['R']))
+            all_S.append(np.array(results["S"]))
+            all_E.append(np.array(results["E"]))
+            all_I.append(np.array(results["I"]))
+            all_R.append(np.array(results["R"]))
 
         # Find the longest simulation
         max_len = max([result.shape[0] for result in all_S])
@@ -107,11 +111,14 @@ class StochasticSEIRAgeGroups:
         # Pad the trajectories with the last value to make them all the same length
         for i in range(Nsim):
             if all_S[i].shape[0] < max_len:
-                padding = [(0, max_len - all_S[i].shape[0]), (0, 0)]  # Only pad the time dimension
-                all_S[i] = np.pad(all_S[i], padding, mode='edge')
-                all_E[i] = np.pad(all_E[i], padding, mode='edge')
-                all_I[i] = np.pad(all_I[i], padding, mode='edge')
-                all_R[i] = np.pad(all_R[i], padding, mode='edge')
+                padding = [
+                    (0, max_len - all_S[i].shape[0]),
+                    (0, 0),
+                ]  # Only pad the time dimension
+                all_S[i] = np.pad(all_S[i], padding, mode="edge")
+                all_E[i] = np.pad(all_E[i], padding, mode="edge")
+                all_I[i] = np.pad(all_I[i], padding, mode="edge")
+                all_R[i] = np.pad(all_R[i], padding, mode="edge")
 
         # Convert lists to arrays to compute the quantiles
         all_S = np.array(all_S)
@@ -121,12 +128,10 @@ class StochasticSEIRAgeGroups:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'E': {q: np.quantile(all_E, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles},
-            'R': {q: np.quantile(all_R, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "E": {q: np.quantile(all_E, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
+            "R": {q: np.quantile(all_R, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
-
-    

--- a/validation/models/stochastic_sir.py
+++ b/validation/models/stochastic_sir.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 class StochasticSIR:
     def __init__(self, S0, I0, R0, beta, gamma, population, time_steps):
@@ -36,12 +37,12 @@ class StochasticSIR:
         I = self.I0
         R = self.R0
 
-        results = {'S': [], 'I': [], 'R': []}
+        results = {"S": [], "I": [], "R": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S)
-            results['I'].append(I)
-            results['R'].append(R)
+            results["S"].append(S)
+            results["I"].append(I)
+            results["R"].append(R)
 
             if I == 0:  # Stop if no more infected individuals
                 break
@@ -81,9 +82,9 @@ class StochasticSIR:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(results['S'])
-            all_I.append(results['I'])
-            all_R.append(results['R'])
+            all_S.append(results["S"])
+            all_I.append(results["I"])
+            all_R.append(results["R"])
 
         # Find the longest simulation
         max_len = max(len(traj) for traj in all_S)
@@ -102,9 +103,9 @@ class StochasticSIR:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles},
-            'R': {q: np.quantile(all_R, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
+            "R": {q: np.quantile(all_R, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
@@ -118,16 +119,25 @@ class StochasticSIR:
                                              and inner keys as the quantiles (e.g., 0.25, 0.5, 0.75).
             quantiles (list of float): The quantiles to plot (e.g., [0.25, 0.5, 0.75]).
         """
-        time_range = range(len(quantile_results['S'][quantiles[0]]))
-        
+        time_range = range(len(quantile_results["S"][quantiles[0]]))
+
         for q in quantiles:
-            plt.plot(time_range, quantile_results['S'][q], label=f'Susceptible ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['I'][q], label=f'Infected ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['R'][q], label=f'Recovered ({q*100:.0f}%)')
+            plt.plot(
+                time_range,
+                quantile_results["S"][q],
+                label=f"Susceptible ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range, quantile_results["I"][q], label=f"Infected ({q * 100:.0f}%)"
+            )
+            plt.plot(
+                time_range,
+                quantile_results["R"][q],
+                label=f"Recovered ({q * 100:.0f}%)",
+            )
 
-        plt.xlabel('Time Steps')
-        plt.ylabel('Population')
+        plt.xlabel("Time Steps")
+        plt.ylabel("Population")
         plt.legend()
-        plt.title('Stochastic SIR Model - Quantiles over Multiple Simulations')
+        plt.title("Stochastic SIR Model - Quantiles over Multiple Simulations")
         plt.show()
-

--- a/validation/models/stochastic_sir_population.py
+++ b/validation/models/stochastic_sir_population.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 class StochasticSIRAgeGroups:
     def __init__(self, S0, I0, R0, beta, gamma, contact_matrix, population, time_steps):
@@ -39,12 +40,12 @@ class StochasticSIRAgeGroups:
         I = self.I0.copy()
         R = self.R0.copy()
 
-        results = {'S': [], 'I': [], 'R': []}
+        results = {"S": [], "I": [], "R": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S.copy())
-            results['I'].append(I.copy())
-            results['R'].append(R.copy())
+            results["S"].append(S.copy())
+            results["I"].append(I.copy())
+            results["R"].append(R.copy())
 
             if np.sum(I) == 0:  # Stop if no more infected individuals
                 break
@@ -87,9 +88,9 @@ class StochasticSIRAgeGroups:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(np.array(results['S']))
-            all_I.append(np.array(results['I']))
-            all_R.append(np.array(results['R']))
+            all_S.append(np.array(results["S"]))
+            all_I.append(np.array(results["I"]))
+            all_R.append(np.array(results["R"]))
 
         # Find the longest simulation
         max_len = max([result.shape[0] for result in all_S])
@@ -97,10 +98,13 @@ class StochasticSIRAgeGroups:
         # Pad the trajectories with the last value to make them all the same length
         for i in range(Nsim):
             if all_S[i].shape[0] < max_len:
-                padding = [(0, max_len - all_S[i].shape[0]), (0, 0)]  # Only pad the time dimension
-                all_S[i] = np.pad(all_S[i], padding, mode='edge')
-                all_I[i] = np.pad(all_I[i], padding, mode='edge')
-                all_R[i] = np.pad(all_R[i], padding, mode='edge')
+                padding = [
+                    (0, max_len - all_S[i].shape[0]),
+                    (0, 0),
+                ]  # Only pad the time dimension
+                all_S[i] = np.pad(all_S[i], padding, mode="edge")
+                all_I[i] = np.pad(all_I[i], padding, mode="edge")
+                all_R[i] = np.pad(all_R[i], padding, mode="edge")
 
         # Convert lists to arrays to compute the quantiles
         all_S = np.array(all_S)
@@ -109,9 +113,9 @@ class StochasticSIRAgeGroups:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles},
-            'R': {q: np.quantile(all_R, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
+            "R": {q: np.quantile(all_R, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
@@ -126,16 +130,27 @@ class StochasticSIRAgeGroups:
             quantiles (list of float): The quantiles to plot (e.g., [0.25, 0.5, 0.75]).
             age_group_idx (int): The index of the age group to plot.
         """
-        time_range = range(quantile_results['S'][quantiles[0]].shape[1])
-        
+        time_range = range(quantile_results["S"][quantiles[0]].shape[1])
+
         for q in quantiles:
-            plt.plot(time_range, quantile_results['S'][q][age_group_idx], label=f'Susceptible ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['I'][q][age_group_idx], label=f'Infected ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['R'][q][age_group_idx], label=f'Recovered ({q*100:.0f}%)')
+            plt.plot(
+                time_range,
+                quantile_results["S"][q][age_group_idx],
+                label=f"Susceptible ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range,
+                quantile_results["I"][q][age_group_idx],
+                label=f"Infected ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range,
+                quantile_results["R"][q][age_group_idx],
+                label=f"Recovered ({q * 100:.0f}%)",
+            )
 
-        plt.xlabel('Time Steps')
-        plt.ylabel('Population')
+        plt.xlabel("Time Steps")
+        plt.ylabel("Population")
         plt.legend()
-        plt.title(f'Stochastic SIR Model (Age Group {age_group_idx})')
+        plt.title(f"Stochastic SIR Model (Age Group {age_group_idx})")
         plt.show()
-

--- a/validation/models/stochastic_sis.py
+++ b/validation/models/stochastic_sis.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 class StochasticSIS:
     def __init__(self, S0, I0, beta, gamma, population, time_steps):
@@ -33,11 +34,11 @@ class StochasticSIS:
         S = self.S0
         I = self.I0
 
-        results = {'S': [], 'I': []}
+        results = {"S": [], "I": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S)
-            results['I'].append(I)
+            results["S"].append(S)
+            results["I"].append(I)
 
             if I == 0:  # Stop if no more infected individuals
                 break
@@ -75,8 +76,8 @@ class StochasticSIS:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(results['S'])
-            all_I.append(results['I'])
+            all_S.append(results["S"])
+            all_I.append(results["I"])
 
         # Find the longest simulation
         max_len = max(len(traj) for traj in all_S)
@@ -93,8 +94,8 @@ class StochasticSIS:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
@@ -108,16 +109,20 @@ class StochasticSIS:
                                              and inner keys as the quantiles (e.g., 0.25, 0.5, 0.75).
             quantiles (list of float): The quantiles to plot (e.g., [0.25, 0.5, 0.75]).
         """
-        time_range = range(len(quantile_results['S'][quantiles[0]]))
-        
+        time_range = range(len(quantile_results["S"][quantiles[0]]))
+
         for q in quantiles:
-            plt.plot(time_range, quantile_results['S'][q], label=f'Susceptible ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['I'][q], label=f'Infected ({q*100:.0f}%)')
+            plt.plot(
+                time_range,
+                quantile_results["S"][q],
+                label=f"Susceptible ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range, quantile_results["I"][q], label=f"Infected ({q * 100:.0f}%)"
+            )
 
-        plt.xlabel('Time Steps')
-        plt.ylabel('Population')
+        plt.xlabel("Time Steps")
+        plt.ylabel("Population")
         plt.legend()
-        plt.title('Stochastic SIS Model - Quantiles over Multiple Simulations')
+        plt.title("Stochastic SIS Model - Quantiles over Multiple Simulations")
         plt.show()
-
-

--- a/validation/models/stochastic_sis_population.py
+++ b/validation/models/stochastic_sis_population.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 class StochasticSISAgeGroups:
     def __init__(self, S0, I0, beta, gamma, contact_matrix, population, time_steps):
@@ -36,11 +37,11 @@ class StochasticSISAgeGroups:
         S = self.S0.copy()
         I = self.I0.copy()
 
-        results = {'S': [], 'I': []}
+        results = {"S": [], "I": []}
 
         for t in range(self.time_steps):
-            results['S'].append(S.copy())
-            results['I'].append(I.copy())
+            results["S"].append(S.copy())
+            results["I"].append(I.copy())
 
             if np.sum(I) == 0:  # Stop if no more infected individuals
                 break
@@ -81,8 +82,8 @@ class StochasticSISAgeGroups:
         # Run Nsim simulations and collect results
         for _ in range(Nsim):
             results = self.simulate()
-            all_S.append(np.array(results['S']))
-            all_I.append(np.array(results['I']))
+            all_S.append(np.array(results["S"]))
+            all_I.append(np.array(results["I"]))
 
         # Find the longest simulation
         max_len = max([result.shape[0] for result in all_S])
@@ -90,9 +91,12 @@ class StochasticSISAgeGroups:
         # Pad the trajectories with the last value to make them all the same length
         for i in range(Nsim):
             if all_S[i].shape[0] < max_len:
-                padding = [(0, max_len - all_S[i].shape[0]), (0, 0)]  # Only pad the time dimension
-                all_S[i] = np.pad(all_S[i], padding, mode='edge')
-                all_I[i] = np.pad(all_I[i], padding, mode='edge')
+                padding = [
+                    (0, max_len - all_S[i].shape[0]),
+                    (0, 0),
+                ]  # Only pad the time dimension
+                all_S[i] = np.pad(all_S[i], padding, mode="edge")
+                all_I[i] = np.pad(all_I[i], padding, mode="edge")
 
         # Convert lists to arrays to compute the quantiles
         all_S = np.array(all_S)
@@ -100,8 +104,8 @@ class StochasticSISAgeGroups:
 
         # Compute the quantiles across the simulations and store them in a dict of dicts
         quantile_results = {
-            'S': {q: np.quantile(all_S, q, axis=0) for q in quantiles},
-            'I': {q: np.quantile(all_I, q, axis=0) for q in quantiles}
+            "S": {q: np.quantile(all_S, q, axis=0) for q in quantiles},
+            "I": {q: np.quantile(all_I, q, axis=0) for q in quantiles},
         }
 
         return quantile_results
@@ -116,14 +120,22 @@ class StochasticSISAgeGroups:
             quantiles (list of float): The quantiles to plot (e.g., [0.25, 0.5, 0.75]).
             age_group_idx (int): The index of the age group to plot.
         """
-        time_range = range(quantile_results['S'][quantiles[0]].shape[1])
-        
-        for q in quantiles:
-            plt.plot(time_range, quantile_results['S'][q][age_group_idx], label=f'Susceptible ({q*100:.0f}%)')
-            plt.plot(time_range, quantile_results['I'][q][age_group_idx], label=f'Infected ({q*100:.0f}%)')
+        time_range = range(quantile_results["S"][quantiles[0]].shape[1])
 
-        plt.xlabel('Time Steps')
-        plt.ylabel('Population')
+        for q in quantiles:
+            plt.plot(
+                time_range,
+                quantile_results["S"][q][age_group_idx],
+                label=f"Susceptible ({q * 100:.0f}%)",
+            )
+            plt.plot(
+                time_range,
+                quantile_results["I"][q][age_group_idx],
+                label=f"Infected ({q * 100:.0f}%)",
+            )
+
+        plt.xlabel("Time Steps")
+        plt.ylabel("Population")
         plt.legend()
-        plt.title(f'Stochastic SIS Model (Age Group {age_group_idx})')
+        plt.title(f"Stochastic SIS Model (Age Group {age_group_idx})")
         plt.show()


### PR DESCRIPTION
I'm opening this PR to apply lint+formatting on the repo using Ruff and ensure that they get applied consistently over time.

List of changes:
- Migrated lint/format config away from `black` + `isort` + `pylint` to `ruff` in pyproject.toml
**NOTE**: For this I chose some initial sane defaults of Ruff (Pylint errors/warnings + pyflakes + pycodestyle + isort), there are many more rules in Ruff which this repo could adopt incrementally.
- Added `dev-requirements.txt` to specify dev dependencies like `pytest`, `ruff`, etc.
- Actually applied the lint / formatting. This is the change that results in the most changes (even if you applied black / isort / pylint you would have had several changes).
- Added a CI step to verify if linter/formatter have been applied correctly. **NOTE**: I haven't added this to the test matrix, just running it on Py 3.11, but it can be moved within the matrix.
- Added a pre-commit hook that one can install to avoid accidental non-formatted commits.
- Added a `CONTRIBUTING.md` explaining both the lint/formatting + how to run tests.


Let me know if this is ok or too many changes (we can tune down the rules, but note that it's less pain to do this now than later).

Ciao!
