### PR TITLE
Add per-simulation time/budget checks to ABC-SMC

### DIFF
--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -217,7 +217,7 @@ def test_abc_smc_gen0_interrupted_returns_empty_results():
     # Use a simulation function that is slow enough to trigger max_time during gen 0
     import time
 
-    def slow_simulation(params):
+    def slow_simulation(_params):
         time.sleep(0.1)
         return {"data": np.array([1.0] * 10)}
 
@@ -261,5 +261,69 @@ def test_abc_smc_without_limits_completes_all_generations(basic_abc_sampler):
     assert len(results.posterior_distributions) == 3
 
     # Each generation should have exactly 10 particles
-    for gen, posterior in results.posterior_distributions.items():
+    for _, posterior in results.posterior_distributions.items():
         assert len(posterior) == 10
+
+
+def test_abc_smc_minimum_epsilon(basic_abc_sampler, capsys):
+    """Test that SMC stops when minimum_epsilon is reached."""
+    results = basic_abc_sampler.calibrate(
+        strategy="smc",
+        num_particles=10,
+        num_generations=10,
+        minimum_epsilon=float("inf"),  # Always triggers after gen 0
+        verbose=True,
+    )
+
+    # Should stop after gen 0 (epsilon < inf is always true once computed)
+    assert len(results.posterior_distributions) >= 1
+
+    captured = capsys.readouterr()
+    assert "Minimum epsilon reached" in captured.out
+
+
+def test_abc_smc_verbose_reports_gen0_interruption(capsys):
+    """Test that SMC verbose output reports when generation 0 is interrupted by time limit."""
+    import time
+
+    def slow_simulation(_params):
+        time.sleep(0.1)
+        return {"data": np.array([1.0] * 10)}
+
+    priors = {
+        "beta": stats.uniform(0.1, 0.5),
+        "gamma": stats.uniform(0.05, 0.2),
+    }
+
+    sampler = ABCSampler(
+        simulation_function=slow_simulation,
+        priors=priors,
+        parameters={"dt": 0.1},
+        observed_data=np.array([90, 82, 75, 68, 62, 57, 52, 48, 44, 40]),
+    )
+
+    sampler.calibrate(
+        strategy="smc",
+        num_particles=1000,
+        num_generations=5,
+        epsilon_schedule=[0.001, 0.001, 0.001, 0.001, 0.001],
+        max_time=timedelta(milliseconds=50),
+        verbose=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "Maximum time or budget reached during generation 0" in captured.out
+
+
+def test_abc_smc_verbose_reports_later_gen_interruption(basic_abc_sampler, capsys):
+    """Test that SMC verbose output reports when a later generation is interrupted by budget limit."""
+    basic_abc_sampler.calibrate(
+        strategy="smc",
+        num_particles=10,
+        num_generations=100,
+        total_simulations_budget=15,
+        verbose=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "keeping last complete generation" in captured.out


### PR DESCRIPTION
## Summary

When setting `max_time` to ABC-SMC, the time check only happens between generations. If a single generation takes very long (e.g., acceptance rate drops near zero), it can overshoot `max_time` indefinitely. This PR adds per-simulation time/budget checks inside `_initialize_particles` and `_run_smc_generation`, discarding incomplete generations and returning the last fully completed one.

`run_rejection` already checks per-simulation. `run_top_fraction` uses a fixed `Nsim` budget. Only `run_smc` needed changes.

## Behaviour

**Before:**
```python
for gen in range(num_generations):
    new_gen = _initialize_particles(...)  # or _run_smc_generation(...)
    results.store(gen, new_gen)
    if _check_stopping_conditions(...):   # checked only between generations
        break
```

**After:**
```python
for gen in range(num_generations):
    new_gen = _initialize_particles(..., start_time, max_time, n_simulations)
        # _check_stopping_conditions called per perturbation attempt
        # returns None if interrupted
    if new_gen is None:
        break                             # keep last complete generation
    results.store(gen, new_gen)
    if _check_stopping_conditions(...):
        break
```

## Changes made

- Add `verbose` parameter to `_check_stopping_conditions` to suppress duplicate messages from inner loops
- Add `start_time`, `max_time`, `total_simulations_budget`, `n_simulations` parameters to `_initialize_particles` and `_run_smc_generation`, returning `None` when interrupted
- Update `run_smc` to handle `None` (incomplete generation), keeping the last complete generation; return empty `CalibrationResults` if generation 0 is interrupted
- Add tests for SMC with time limit, budget limit, gen 0 interruption, and no-limits backward compatibility