### PR TITLE
Bug fix: Skip non-numeric arrays in quantile computation

### DIFF
--- a/epydemix/calibration/calibration_results.py
+++ b/epydemix/calibration/calibration_results.py
@@ -210,6 +210,8 @@ class CalibrationResults:
             import warnings
 
             for key, vals in trajectories.items():
+                if not np.issubdtype(vals.dtype, np.number):
+                    continue
                 nan_prop = np.isnan(vals).mean(axis=0)
                 max_nan_prop = np.max(nan_prop)
                 if max_nan_prop > 0.5:
@@ -219,6 +221,8 @@ class CalibrationResults:
                     )
 
         for key, vals in trajectories.items():
+            if not np.issubdtype(vals.dtype, np.number):
+                continue
             data[key] = [
                 val for q in quantiles for val in quantile_func(vals, q, axis=0)
             ]


### PR DESCRIPTION
## Summary

`_compute_quantiles` crashes with `TypeError: ufunc 'isnan' not supported` when trajectory dicts contain **non-numeric** values (e.g. dates). This was surfaced after adding `ignore_nan=True` to quantile calls, which activates the `np.isnan` check.

## Changes made

- Skip non-numeric arrays in the NaN check and quantile computation loops in `_compute_quantiles`
- Add tests for non-numeric array handling