### PR TITLE
Version 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # Basic package metadata
 name = "epydemix" 
-version = "1.0.2" 
+version = "1.1.0" 
 description = "A Python package for epidemic modeling, simulation, and calibration"
 authors = [
     { name = "Nicolò Gozzi", email = "nic.gozzi@gmail.com" }, 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="epydemix",
-    version="1.0.2",
+    version="1.1.0",
     author="The Epydemix Developers",
     author_email="epydemix@isi.it",
     description="A Python package for epidemic modeling, simulation, and calibration",


### PR DESCRIPTION
After bug fix https://github.com/epistorm/epydemix/pull/10 is merged, I think we can bump the version to v1.1.0.

For managing explicit dependency versions, I think we should also make lock files (uv.lock) and commit it.